### PR TITLE
Hash functions cleanup

### DIFF
--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 k256 = { version = "0.7", default-features = false, features = ["ecdsa", "arithmetic"] }
 blake2 = "0.9"
-sha3 = "0.9"
 sha2 = "0.9"
 chacha20poly1305 = "0.7"
 hkdf = "0.10"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 k256 = { version = "0.7", default-features = false, features = ["ecdsa", "arithmetic"] }
-blake2 = "0.9"
 sha2 = "0.9"
 chacha20poly1305 = "0.7"
 hkdf = "0.10"

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -198,7 +198,6 @@ impl CapsuleFrag {
         let v2 = self.proof.point_v2;
         let u2 = self.proof.kfrag_pok;
 
-        // TODO (#2): original uses ExtendedKeccak here
         let h = ScalarDigest::new()
             .chain_points(&[e, e1, e2, v, v1, v2, u, u1, u2])
             .chain_scalar(&self.proof.metadata)

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -268,7 +268,7 @@ impl SerializableToArray for PublicKey {
 #[cfg(test)]
 mod tests {
 
-    use sha3::Sha3_256;
+    use sha2::Sha256;
     use signature::digest::Digest;
 
     use super::{PublicKey, SecretKey};
@@ -295,11 +295,11 @@ mod tests {
     fn test_sign_and_verify() {
         let sk = SecretKey::random();
         let message = b"asdafdahsfdasdfasd";
-        let digest = Sha3_256::new().chain(message);
+        let digest = Sha256::new().chain(message);
         let signature = sk.sign_digest(digest);
 
         let pk = PublicKey::from_secret_key(&sk);
-        let digest = Sha3_256::new().chain(message);
+        let digest = Sha256::new().chain(message);
         assert!(pk.verify_digest(digest, &signature));
     }
 }

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -1,18 +1,18 @@
 use alloc::boxed::Box;
 
 use aead::{Aead, AeadInPlace, Payload};
-use blake2::Blake2b;
 use chacha20poly1305::aead::NewAead;
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use generic_array::{typenum::Unsigned, GenericArray};
 use hkdf::Hkdf;
 use rand_core::OsRng;
 use rand_core::RngCore;
+use sha2::Sha256;
 
 type KdfSize = <ChaCha20Poly1305 as NewAead>::KeySize;
 
 fn kdf(seed: &[u8], salt: Option<&[u8]>, info: Option<&[u8]>) -> GenericArray<u8, KdfSize> {
-    let hk = Hkdf::<Blake2b>::new(salt, &seed);
+    let hk = Hkdf::<Sha256>::new(salt, &seed);
 
     let mut okm = GenericArray::<u8, KdfSize>::default();
 

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -1,51 +1,49 @@
-use blake2::VarBlake2b;
-use digest::{Digest, Update, VariableOutput};
-use generic_array::typenum::Unsigned;
+use digest::Digest;
+use generic_array::sequence::Concat;
 use generic_array::GenericArray;
 use sha2::Sha256;
+use typenum::U1;
 
 use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
 use crate::traits::SerializableToArray;
 
-/// Hashes arbitrary data into a valid EC point of the specified curve,
+/// Hashes arbitrary data with the given domain separation tag
+/// into a valid EC point of the specified curve,
 /// using the try-and-increment method.
-/// It admits an optional label as an additional input to the hash function.
-/// It uses BLAKE2b (with a digest size of 64 bytes) as the internal hash function.
 ///
 /// WARNING: Do not use when the input data is secret, as this implementation is not
 /// in constant time, and hence, it is not safe with respect to timing attacks.
-pub fn unsafe_hash_to_point(data: &[u8], label: &[u8]) -> Option<CurvePoint> {
+pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
     // NOTE: Yes, this function is hacky, but it is the only way
     // to hash to a point with an *unknown* discrete log.
     // Don't replace with hashing to scalar and multiplying by a generator!
 
-    let len_data = (data.len() as u32).to_be_bytes();
-    let len_label = (label.len() as u32).to_be_bytes();
+    // TODO (#35): use the standard method when it is available in RustCrypto.
 
-    type PointSize = <CurvePoint as SerializableToArray>::Size;
-    let point_size = PointSize::to_usize();
-    let mut arr = GenericArray::<u8, PointSize>::default();
+    // Fixed sign prefix. Halves the range of the generated points, but we only need one,
+    // and it is always the same.
+    let sign_prefix = GenericArray::<u8, U1>::from_slice(&[2u8]);
+
+    let dst_len = (dst.len() as u32).to_be_bytes();
+    let data_len = (data.len() as u32).to_be_bytes();
 
     // We use an internal 32-bit counter as additional input
     let mut i = 0u32;
     while i < <u32>::MAX {
         let ibytes = (i as u32).to_be_bytes();
 
-        // May fail if `point_size` is too large for the hashing algorithm.
-        let digest = VarBlake2b::new(point_size).ok()?;
-        digest
-            .chain(&len_label)
-            .chain(label)
-            .chain(&len_data)
-            .chain(data)
-            .chain(&ibytes)
-            .finalize_variable(|buf| arr = *GenericArray::<u8, PointSize>::from_slice(buf));
+        let mut digest = Sha256::new();
+        digest.update(&dst_len);
+        digest.update(dst);
+        digest.update(&data_len);
+        digest.update(data);
+        digest.update(&ibytes);
+        let result = digest.finalize();
 
         // Set the sign byte
-        let arr_data = arr.as_mut_slice();
-        arr_data[0] = if arr_data[0] & 1 == 0 { 2 } else { 3 };
+        let maybe_point_bytes = sign_prefix.concat(result);
 
-        let maybe_point = CurvePoint::from_bytes(&arr);
+        let maybe_point = CurvePoint::from_bytes(&maybe_point_bytes);
         if maybe_point.is_some() {
             return maybe_point;
         }
@@ -94,6 +92,7 @@ impl ScalarDigest {
     }
 
     pub fn finalize(self) -> CurveScalar {
+        // TODO (#35): use the standard method when it is available in RustCrypto.
         CurveScalar::from_digest(self.0)
     }
 }
@@ -143,18 +142,18 @@ mod tests {
     #[test]
     fn test_unsafe_hash_to_point() {
         let data = b"abcdefg";
-        let label = b"sdasdasd";
-        let p = unsafe_hash_to_point(&data[..], &label[..]);
-        let p_same = unsafe_hash_to_point(&data[..], &label[..]);
+        let dst = b"sdasdasd";
+        let p = unsafe_hash_to_point(&dst[..], &data[..]);
+        let p_same = unsafe_hash_to_point(&dst[..], &data[..]);
         assert_eq!(p, p_same);
 
         let data2 = b"abcdefgh";
-        let p_data2 = unsafe_hash_to_point(&data2[..], &label[..]);
+        let p_data2 = unsafe_hash_to_point(&dst[..], &data2[..]);
         assert_ne!(p, p_data2);
 
-        let label2 = b"sdasdasds";
-        let p_label2 = unsafe_hash_to_point(&data[..], &label2[..]);
-        assert_ne!(p, p_label2);
+        let dst2 = b"sdasdasds";
+        let p_dst2 = unsafe_hash_to_point(&dst2[..], &data[..]);
+        assert_ne!(p, p_dst2);
     }
 
     #[test]

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -2,7 +2,7 @@ use blake2::VarBlake2b;
 use digest::{Digest, Update, VariableOutput};
 use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
-use sha3::Sha3_256;
+use sha2::Sha256;
 
 use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
 use crate::traits::SerializableToArray;
@@ -58,12 +58,11 @@ pub fn unsafe_hash_to_point(data: &[u8], label: &[u8]) -> Option<CurvePoint> {
     None
 }
 
-pub(crate) struct ScalarDigest(Sha3_256);
+pub(crate) struct ScalarDigest(Sha256);
 
-// TODO (#2): original uses ExtendedKeccak here
 impl ScalarDigest {
     pub fn new() -> Self {
-        Self(Sha3_256::new())
+        Self(Sha256::new())
     }
 
     pub fn new_with_dst(bytes: &[u8]) -> Self {
@@ -99,11 +98,11 @@ impl ScalarDigest {
     }
 }
 
-pub(crate) struct SignatureDigest(Sha3_256);
+pub(crate) struct SignatureDigest(Sha256);
 
 impl SignatureDigest {
     pub fn new() -> Self {
-        Self(Sha3_256::new())
+        Self(Sha256::new())
     }
 
     fn chain_impl(self, bytes: &[u8]) -> Self {

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -4,6 +4,7 @@
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing::ScalarDigest;
 
+// TODO (#39): Ideally this should return a non-zero scalar.
 pub(crate) fn hash_to_polynomial_arg(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,
@@ -18,6 +19,8 @@ pub(crate) fn hash_to_polynomial_arg(
         .finalize()
 }
 
+// TODO (#39): Ideally this should return a non-zero scalar.
+// (when it does, the loop in `KeyFragFactory::new()` can be removed)
 pub(crate) fn hash_to_shared_secret(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,

--- a/umbral-pre/src/params.rs
+++ b/umbral-pre/src/params.rs
@@ -13,15 +13,15 @@ pub struct Parameters {
 impl Parameters {
     /// Creates a new parameter object.
     pub fn new() -> Self {
+        // Some future-proofing for a scenario where someone uses a different generator.
+        // We wouldn't want `u` to be the same in that case.
         let g = CurvePoint::generator();
         let g_bytes = g.to_array();
-
-        let parameters_seed = b"NuCypher/UmbralParameters/u";
 
         // Only fails with a minuscule probability,
         // or if the size of a point is too large for the hasher.
         // In any case, we will notice it in tests.
-        let u = unsafe_hash_to_point(&g_bytes, parameters_seed).unwrap();
+        let u = unsafe_hash_to_point(b"POINT_U", &g_bytes).unwrap();
 
         Self { u }
     }


### PR DESCRIPTION
Time to stop with direct pushing to upstream and start proper procedures.

- remove the use of all extraneous hashing (fixes #2), leaving only SHA256
- in particular, halve the range of `unsafe_hash_to_point()`, since SHA256 gives us 32 bytes and we need 33 to fully define a point. 

Not implementing the standardized hash-to-point in this PR, see #35