### PR TITLE
Get rid of exposed domain separation tags and use dedicated functions instead

### DIFF
--- a/umbral-pre/src/constants.rs
+++ b/umbral-pre/src/constants.rs
@@ -1,3 +1,0 @@
-pub(crate) const NON_INTERACTIVE: &[u8] = b"NON_INTERACTIVE";
-
-pub(crate) const X_COORDINATE: &[u8] = b"X_COORDINATE";

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -63,7 +63,11 @@ pub(crate) struct ScalarDigest(Sha3_256);
 // TODO (#2): original uses ExtendedKeccak here
 impl ScalarDigest {
     pub fn new() -> Self {
-        Self(Sha3_256::new()).chain_bytes(b"hash_to_curvebn")
+        Self(Sha3_256::new())
+    }
+
+    pub fn new_with_dst(bytes: &[u8]) -> Self {
+        Self::new().chain_bytes(bytes)
     }
 
     fn chain_impl(self, bytes: &[u8]) -> Self {

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -1,0 +1,31 @@
+//! This module contains hashing sequences with included domain separation tags
+//! shared between different parts of the code.
+
+use crate::curve::{CurvePoint, CurveScalar};
+use crate::hashing::ScalarDigest;
+
+pub(crate) fn hash_to_polynomial_arg(
+    precursor: &CurvePoint,
+    pubkey: &CurvePoint,
+    dh_point: &CurvePoint,
+    id: &CurveScalar,
+) -> CurveScalar {
+    ScalarDigest::new_with_dst(b"POLYNOMIAL_ARG")
+        .chain_point(precursor)
+        .chain_point(pubkey)
+        .chain_point(dh_point)
+        .chain_scalar(id)
+        .finalize()
+}
+
+pub(crate) fn hash_to_shared_secret(
+    precursor: &CurvePoint,
+    pubkey: &CurvePoint,
+    dh_point: &CurvePoint,
+) -> CurveScalar {
+    ScalarDigest::new_with_dst(b"SHARED_SECRET")
+        .chain_point(precursor)
+        .chain_point(pubkey)
+        .chain_point(dh_point)
+        .finalize()
+}

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -96,10 +96,10 @@ extern crate typenum;
 pub mod bench; // Re-export some internals for benchmarks.
 mod capsule;
 mod capsule_frag;
-mod constants;
 mod curve;
 mod dem;
 mod hashing;
+mod hashing_ds;
 mod key_frag;
 mod params;
 mod pre;


### PR DESCRIPTION
Fixes #28

As we have discussed, we need to keep the DSTs, but they're better off hidden in the respective functions.

What do you think, keep strings as tags, or use single bytes to make it a little more portable?