### PR TITLE
Introduce KeyFragID instead of using a Scalar for this purpose

### DIFF
--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -2,7 +2,7 @@ use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::curve::{PublicKey, Signature};
 use crate::hashing::{ScalarDigest, SignatureDigest};
-use crate::key_frag::KeyFrag;
+use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::traits::SerializableToArray;
 
 use generic_array::sequence::Concat;
@@ -115,7 +115,7 @@ impl CapsuleFragProof {
 pub struct CapsuleFrag {
     pub(crate) point_e1: CurvePoint,
     pub(crate) point_v1: CurvePoint,
-    pub(crate) kfrag_id: CurveScalar,
+    pub(crate) kfrag_id: KeyFragID,
     pub(crate) precursor: CurvePoint,
     pub(crate) proof: CapsuleFragProof,
 }
@@ -137,7 +137,7 @@ impl SerializableToArray for CapsuleFrag {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
         let (point_e1, rest) = CurvePoint::take(*arr)?;
         let (point_v1, rest) = CurvePoint::take(rest)?;
-        let (kfrag_id, rest) = CurveScalar::take(rest)?;
+        let (kfrag_id, rest) = KeyFragID::take(rest)?;
         let (precursor, rest) = CurvePoint::take(rest)?;
         let proof = CapsuleFragProof::take_last(rest)?;
         Some(Self {
@@ -209,7 +209,7 @@ impl CapsuleFrag {
         let kfrag_id = self.kfrag_id;
 
         let valid_kfrag_signature = SignatureDigest::new()
-            .chain_scalar(&kfrag_id)
+            .chain_bytes(&kfrag_id)
             .chain_pubkey(delegating_pk)
             .chain_pubkey(receiving_pk)
             .chain_point(&u1)

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -1,16 +1,18 @@
 use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::curve::{PublicKey, Signature};
-use crate::hashing::{BytesDigestOutputSize, ScalarDigest, SignatureDigest};
+use crate::hashing::{ScalarDigest, SignatureDigest};
 use crate::hashing_ds::hash_metadata;
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::traits::SerializableToArray;
 
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
-use typenum::op;
+use typenum::{op, U32};
 
-type HashedMetadataSize = BytesDigestOutputSize;
+// The compiler will ensure that's the array length we are getting from the hash function.
+// Hardcoding here for the purposes of the formal specification.
+type HashedMetadataSize = U32;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct HashedMetadata(GenericArray<u8, HashedMetadataSize>);

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -16,10 +16,7 @@ fn kdf(seed: &[u8], salt: Option<&[u8]>, info: Option<&[u8]>) -> GenericArray<u8
 
     let mut okm = GenericArray::<u8, KdfSize>::default();
 
-    let def_info = match info {
-        Some(x) => x,
-        None => &[],
-    };
+    let def_info = info.unwrap_or(&[]);
 
     // We can only get an error here if `KdfSize` is too large, and it's known at compile-time.
     hk.expand(&def_info, &mut okm).unwrap();

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -162,23 +162,23 @@ mod tests {
     use super::{
         unsafe_hash_to_point, BytesDigest, BytesDigestOutputSize, ScalarDigest, SignatureDigest,
     };
-    use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey};
+    use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
     use generic_array::GenericArray;
 
     #[test]
     fn test_unsafe_hash_to_point() {
         let data = b"abcdefg";
         let dst = b"sdasdasd";
-        let p = unsafe_hash_to_point(&dst[..], &data[..]);
-        let p_same = unsafe_hash_to_point(&dst[..], &data[..]);
+        let p: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data[..]);
+        let p_same: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data[..]);
         assert_eq!(p, p_same);
 
         let data2 = b"abcdefgh";
-        let p_data2 = unsafe_hash_to_point(&dst[..], &data2[..]);
+        let p_data2: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data2[..]);
         assert_ne!(p, p_data2);
 
         let dst2 = b"sdasdasds";
-        let p_dst2 = unsafe_hash_to_point(&dst2[..], &data[..]);
+        let p_dst2: Option<CurvePoint> = unsafe_hash_to_point(&dst2[..], &data[..]);
         assert_ne!(p, p_dst2);
     }
 
@@ -188,17 +188,17 @@ mod tests {
         let p2 = &p1 + &p1;
         let bytes: &[u8] = b"foobar";
 
-        let s = ScalarDigest::new()
+        let s: CurveScalar = ScalarDigest::new()
             .chain_points(&[p1, p2])
             .chain_bytes(bytes)
             .finalize();
-        let s_same = ScalarDigest::new()
+        let s_same: CurveScalar = ScalarDigest::new()
             .chain_points(&[p1, p2])
             .chain_bytes(bytes)
             .finalize();
         assert_eq!(s, s_same);
 
-        let s_diff = ScalarDigest::new()
+        let s_diff: CurveScalar = ScalarDigest::new()
             .chain_points(&[p2, p1])
             .chain_bytes(bytes)
             .finalize();
@@ -216,7 +216,7 @@ mod tests {
         let signing_sk = SecretKey::random();
         let signing_pk = PublicKey::from_secret_key(&signing_sk);
 
-        let signature = SignatureDigest::new()
+        let signature: Signature = SignatureDigest::new()
             .chain_point(&p2)
             .chain_bytes(&bytes)
             .chain_bool(b)

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -71,8 +71,8 @@ impl ScalarDigest {
         Self(digest::Digest::chain(self.0, bytes))
     }
 
-    pub fn chain_bytes(self, bytes: &[u8]) -> Self {
-        self.chain_impl(bytes)
+    pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
+        self.chain_impl(bytes.as_ref())
     }
 
     pub fn chain_scalar(self, scalar: &CurveScalar) -> Self {
@@ -108,8 +108,8 @@ impl SignatureDigest {
         Self(digest::Digest::chain(self.0, bytes))
     }
 
-    pub fn chain_scalar(self, scalar: &CurveScalar) -> Self {
-        self.chain_impl(&scalar.to_array())
+    pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
+        self.chain_impl(bytes.as_ref())
     }
 
     pub fn chain_point(self, point: &CurvePoint) -> Self {
@@ -187,7 +187,7 @@ mod tests {
     fn test_signature_digest() {
         let p1 = CurvePoint::generator();
         let p2 = &p1 + &p1;
-        let rs = CurveScalar::random_nonzero();
+        let bytes = b"asdfghjk";
         let b = true;
         let pk = PublicKey::from_secret_key(&SecretKey::random());
 
@@ -196,14 +196,14 @@ mod tests {
 
         let signature = SignatureDigest::new()
             .chain_point(&p2)
-            .chain_scalar(&rs)
+            .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .sign(&signing_sk);
 
         let same_values_same_key = SignatureDigest::new()
             .chain_point(&p2)
-            .chain_scalar(&rs)
+            .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .verify(&signing_pk, &signature);
@@ -211,7 +211,7 @@ mod tests {
 
         let same_values_different_key = SignatureDigest::new()
             .chain_point(&p2)
-            .chain_scalar(&rs)
+            .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .verify(&pk, &signature);
@@ -220,7 +220,7 @@ mod tests {
 
         let different_values_same_key = SignatureDigest::new()
             .chain_point(&p1)
-            .chain_scalar(&rs)
+            .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .verify(&signing_pk, &signature);

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -1,8 +1,10 @@
 //! This module contains hashing sequences with included domain separation tags
 //! shared between different parts of the code.
 
+use generic_array::GenericArray;
+
 use crate::curve::{CurvePoint, CurveScalar};
-use crate::hashing::ScalarDigest;
+use crate::hashing::{BytesDigest, BytesDigestOutputSize, ScalarDigest};
 use crate::key_frag::KeyFragID;
 
 // TODO (#39): Ideally this should return a non-zero scalar.
@@ -31,5 +33,11 @@ pub(crate) fn hash_to_shared_secret(
         .chain_point(precursor)
         .chain_point(pubkey)
         .chain_point(dh_point)
+        .finalize()
+}
+
+pub(crate) fn hash_metadata(bytes: &[u8]) -> GenericArray<u8, BytesDigestOutputSize> {
+    BytesDigest::new_with_dst(b"METADATA")
+        .chain_bytes(bytes)
         .finalize()
 }

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -3,19 +3,20 @@
 
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing::ScalarDigest;
+use crate::key_frag::KeyFragID;
 
 // TODO (#39): Ideally this should return a non-zero scalar.
 pub(crate) fn hash_to_polynomial_arg(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,
     dh_point: &CurvePoint,
-    id: &CurveScalar,
+    kfrag_id: &KeyFragID,
 ) -> CurveScalar {
     ScalarDigest::new_with_dst(b"POLYNOMIAL_ARG")
         .chain_point(precursor)
         .chain_point(pubkey)
         .chain_point(dh_point)
-        .chain_scalar(id)
+        .chain_bytes(kfrag_id)
         .finalize()
 }
 


### PR DESCRIPTION
A part of #27
Fixes #21

- now `KeyFrag` identifier matches the one used in `PyUmbral`. 
- hash `CapsuleFrag` metadata in bytes instead of a scalar