### PR TITLE
Interfacing with Python

### DIFF
--- a/umbral-pre-python/Cargo.toml
+++ b/umbral-pre-python/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.12.3", features = ["extension-module"] }
+pyo3 = { version = "0.13", features = ["extension-module"] }
 umbral-pre = { path = "../umbral-pre" }
 generic-array = "0.14"

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -85,7 +85,7 @@ API reference
 
     A reencrypted fragment of an encapsulated symmetric key.
 
-    .. py:method:: verify(capsule: Capsule, signing_pk: PublicKey, delegating_pk: PublicKey, receiving_pk: PublicKey, metadata: Optional[bytes]) -> bool
+    .. py:method:: verify(capsule: Capsule, delegating_pk: PublicKey, receiving_pk: PublicKey, signing_pk: PublicKey, metadata: Optional[bytes]) -> bool
 
         Verifies the integrity of the fragment.
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -34,18 +34,12 @@ API reference
 
         Creates a public key corresponding to the given secret key.
 
-
-.. py:class:: Parameters()
-
-    A scheme parameters object.
-
-
 .. py:class:: Capsule
 
     An encapsulated symmetric key.
 
 
-.. py:function:: encrypt(params: Parameters, pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]
+.. py:function:: encrypt(pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]
 
     Creates a symmetric key, encrypts ``plaintext`` with it, and returns the encapsulated symmetric key along with the ciphertext. ``pk`` is the public key of the recipient.
 
@@ -53,7 +47,7 @@ API reference
 
     Decrypts ``ciphertext`` with the key used to encrypt it.
 
-.. py:function:: generate_kfrags(params: Parameters, delegating_sk: SecretKey, receiving_pk: PublicKey, signing_sk: SecretKey, threshold: int, num_kfrags: int, sign_delegating_key: bool, sign_receiving_key: bool) -> List[KeyFrag]
+.. py:function:: generate_kfrags(delegating_sk: SecretKey, receiving_pk: PublicKey, signing_sk: SecretKey, threshold: int, num_kfrags: int, sign_delegating_key: bool, sign_receiving_key: bool) -> List[KeyFrag]
 
     Generates ``num_kfrags`` key fragments that can be used to reencrypt the capsule for the holder of the secret key corresponding to ``receiving_pk``. ``threshold`` fragments will be enough for decryption.
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -26,6 +26,18 @@ API reference
 
         Generates a new secret key.
 
+.. py:class:: SecretKeyFactory
+
+    A deterministic generator of :py:class:`SecretKey` objects.
+
+    .. py:staticmethod:: random() -> SecretKeyFactory
+
+        Generates a new random factory.
+
+    .. py:method:: secret_key_by_label(label: bytes) -> SecretKey
+
+        Generates a new :py:class:`SecretKey` using ``label`` as a seed.
+
 .. py:class:: PublicKey
 
     An ``umbral-pre`` public key object.
@@ -37,7 +49,6 @@ API reference
 .. py:class:: Capsule
 
     An encapsulated symmetric key.
-
 
 .. py:function:: encrypt(pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -56,8 +56,7 @@ API reference
 .. py:function:: reencrypt(capsule: Capsule, kfrag: KeyFrag, metadata: Optional[bytes]) -> CapsuleFrag
 
     Reencrypts a capsule using a key fragment.
-    May include optional ``metadata`` in the resulting capsule fragment.
-
+    May include optional ``metadata`` to sign.
 
 .. py:function:: decrypt_reencrypted(decrypting_sk: SecretKey, delegating_pk: PublicKey, capsule: Capsule, cfrags: Sequence[CapsuleFrag], ciphertext: bytes) -> Optional[bytes]
 
@@ -75,7 +74,7 @@ API reference
 
     A reencrypted fragment of an encapsulated symmetric key.
 
-    .. py:method:: verify(capsule: Capsule, signing_pk: PublicKey, delegating_pk: PublicKey, receiving_pk: PublicKey) -> bool
+    .. py:method:: verify(capsule: Capsule, signing_pk: PublicKey, delegating_pk: PublicKey, receiving_pk: PublicKey, metadata: Optional[bytes]) -> bool
 
         Verifies the integrity of the fragment.
 

--- a/umbral-pre-python/example/example.py
+++ b/umbral-pre-python/example/example.py
@@ -59,15 +59,15 @@ kfrags = umbral_pre.generate_kfrags(
 # Ursulas can optionally check that the received kfrags
 # are valid and perform the reencryption.
 
-metadata = b"metadata"
-
 # Ursula 0
+metadata0 = b"metadata0"
 assert kfrags[0].verify(signing_pk, alice_pk, bob_pk)
-cfrag0 = umbral_pre.reencrypt(capsule, kfrags[0], metadata)
+cfrag0 = umbral_pre.reencrypt(capsule, kfrags[0], metadata0)
 
 # Ursula 1
+metadata1 = b"metadata1"
 assert kfrags[1].verify(signing_pk, alice_pk, bob_pk)
-cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1], metadata)
+cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1], metadata1)
 
 # ...
 
@@ -75,8 +75,8 @@ cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1], metadata)
 # and then decrypts the re-encrypted ciphertext.
 
 # Bob can optionally check that cfrags are valid
-assert cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk)
-assert cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk)
+assert cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk, metadata0)
+assert cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk, metadata1)
 
 # Decryption by Bob
 plaintext_bob = umbral_pre.decrypt_reencrypted(

--- a/umbral-pre-python/example/example.py
+++ b/umbral-pre-python/example/example.py
@@ -21,10 +21,8 @@ bob_pk = umbral_pre.PublicKey.from_secret_key(bob_sk)
 # Note that anyone with Alice's public key
 # can perform this operation.
 
-params = umbral_pre.Parameters()
 plaintext = b"peace at dawn"
-capsule, ciphertext = umbral_pre.encrypt(
-    params, alice_pk, plaintext)
+capsule, ciphertext = umbral_pre.encrypt(alice_pk, plaintext)
 
 # Since data was encrypted with Alice's public key,
 # Alice can open the capsule and decrypt the ciphertext
@@ -43,7 +41,7 @@ m = 2 # how many should be enough to decrypt
 
 # Split Re-Encryption Key Generation (aka Delegation)
 kfrags = umbral_pre.generate_kfrags(
-    params, alice_sk, bob_pk, signing_sk, m, n,
+    alice_sk, bob_pk, signing_sk, m, n,
     True, # add the delegating key (alice_pk) to the signature
     True, # add the receiving key (bob_pk) to the signature
 )

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -306,13 +306,10 @@ fn _umbral(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Capsule>()?;
     m.add_class::<KeyFrag>()?;
     m.add_class::<CapsuleFrag>()?;
-    m.add_function(wrap_pyfunction!(encrypt, m)?).unwrap();
-    m.add_function(wrap_pyfunction!(decrypt_original, m)?)
-        .unwrap();
-    m.add_function(wrap_pyfunction!(generate_kfrags, m)?)
-        .unwrap();
-    m.add_function(wrap_pyfunction!(reencrypt, m)?).unwrap();
-    m.add_function(wrap_pyfunction!(decrypt_reencrypted, m)?)
-        .unwrap();
+    m.add_function(wrap_pyfunction!(encrypt, m)?)?;
+    m.add_function(wrap_pyfunction!(decrypt_original, m)?)?;
+    m.add_function(wrap_pyfunction!(generate_kfrags, m)?)?;
+    m.add_function(wrap_pyfunction!(reencrypt, m)?)?;
+    m.add_function(wrap_pyfunction!(decrypt_reencrypted, m)?)?;
     Ok(())
 }

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -193,12 +193,14 @@ impl CapsuleFrag {
         signing_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
+        metadata: Option<&[u8]>,
     ) -> bool {
         self.backend.verify(
             &capsule.backend,
             &signing_pk.backend,
             &delegating_pk.backend,
             &receiving_pk.backend,
+            metadata,
         )
     }
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -237,16 +237,16 @@ impl CapsuleFrag {
     pub fn verify(
         &self,
         capsule: &Capsule,
-        signing_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
+        signing_pk: &PublicKey,
         metadata: Option<&[u8]>,
     ) -> bool {
         self.backend.verify(
             &capsule.backend,
-            &signing_pk.backend,
             &delegating_pk.backend,
             &receiving_pk.backend,
+            &signing_pk.backend,
             metadata,
         )
     }

--- a/umbral-pre-python/umbral_pre/__init__.py
+++ b/umbral-pre-python/umbral_pre/__init__.py
@@ -1,6 +1,9 @@
 from ._umbral import (
     SecretKey,
     PublicKey,
+    Capsule,
+    KeyFrag,
+    CapsuleFrag,
     encrypt,
     decrypt_original,
     decrypt_reencrypted,

--- a/umbral-pre-python/umbral_pre/__init__.py
+++ b/umbral-pre-python/umbral_pre/__init__.py
@@ -1,7 +1,6 @@
 from ._umbral import (
     SecretKey,
     PublicKey,
-    Parameters,
     encrypt,
     decrypt_original,
     decrypt_reencrypted,

--- a/umbral-pre-python/umbral_pre/__init__.py
+++ b/umbral-pre-python/umbral_pre/__init__.py
@@ -1,5 +1,6 @@
 from ._umbral import (
     SecretKey,
+    SecretKeyFactory,
     PublicKey,
     Capsule,
     KeyFrag,

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -52,6 +52,7 @@ class CapsuleFrag:
             signing_pk: PublicKey,
             delegating_pk: PublicKey,
             receiving_pk: PublicKey,
+            metadata: Optional[bytes],
             ) -> bool:
         ...
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -60,9 +60,9 @@ class CapsuleFrag:
     def verify(
             self,
             capsule: Capsule,
-            signing_pk: PublicKey,
             delegating_pk: PublicKey,
             receiving_pk: PublicKey,
+            signing_pk: PublicKey,
             metadata: Optional[bytes],
             ) -> bool:
         ...

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -6,6 +6,17 @@ class SecretKey:
     def random() -> SecretKey:
         ...
 
+
+class SecretKeyFactory:
+
+    @staticmethod
+    def random() -> SecretKeyFactory:
+        ...
+
+    def secret_key_by_label(self, label: bytes) -> SecretKey:
+        ...
+
+
 class PublicKey:
     @staticmethod
     def from_secret_key(sk: SecretKey) -> PublicKey:

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -12,13 +12,10 @@ class PublicKey:
         ...
 
 
-class Parameters: ...
-
-
 class Capsule: ...
 
 
-def encrypt(params: Parameters, pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
+def encrypt(pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
     ...
 
 
@@ -37,7 +34,6 @@ class KeyFrag:
 
 
 def generate_kfrags(
-        params: Parameters,
         delegating_sk: SecretKey,
         receiving_pk: PublicKey,
         signing_sk: SecretKey,

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -67,15 +67,19 @@ let kfrags = umbral.generate_kfrags(
 // Ursulas can optionally check that the received kfrags are valid
 // and perform the reencryption
 
-let metadata = "asbdasdasd";
-
 // Ursula 0
-console.assert(kfrags[0].verify(signing_pk, alice_pk, bob_pk), "kfrag0 is invalid");
-let cfrag0 = umbral.reencrypt(capsule, kfrags[0], enc.encode(metadata));
+let metadata0 = enc.encode("metadata0")
+console.assert(
+    kfrags[0].verify_with_delegating_and_receiving_keys(signing_pk, alice_pk, bob_pk),
+    "kfrag0 is invalid");
+let cfrag0 = umbral.reencrypt(capsule, kfrags[0], metadata0);
 
 // Ursula 1
-console.assert(kfrags[1].verify(signing_pk, alice_pk, bob_pk), "kfrag1 is invalid");
-let cfrag1 = umbral.reencrypt(capsule, kfrags[1], enc.encode(metadata));
+let metadata1 = enc.encode("metadata1");
+console.assert(
+    kfrags[1].verify_with_delegating_and_receiving_keys(signing_pk, alice_pk, bob_pk),
+    "kfrag1 is invalid");
+let cfrag1 = umbral.reencrypt(capsule, kfrags[1], metadata1);
 
 // ...
 
@@ -83,8 +87,8 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1], enc.encode(metadata));
 // and then decrypts the re-encrypted ciphertext.
 
 // Bob can optionally check that cfrags are valid
-console.assert(cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk), "cfrag0 is invalid");
-console.assert(cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk), "cfrag1 is invalid");
+console.assert(cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk, metadata0), "cfrag0 is invalid");
+console.assert(cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk, metadata1), "cfrag1 is invalid");
 
 // Another deviation from the Rust API.
 // wasm-pack does not support taking arrays as arguments,

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -32,14 +32,13 @@ let bob_pk = umbral.PublicKey.from_secret_key(bob_sk);
 // Invocation of `encrypt()` returns both the ciphertext and a capsule.
 // Note that anyone with Alice's public key can perform this operation.
 
-let params = new umbral.Parameters();
 let plaintext = "Plaintext message";
 let plaintext_bytes = enc.encode(plaintext);
 
 // The API here slightly differs from that in Rust.
 // Since wasm-pack does not support returning tuples, we return an object containing
 // the ciphertext and the capsule.
-let result = umbral.encrypt(params, alice_pk, plaintext_bytes);
+let result = umbral.encrypt(alice_pk, plaintext_bytes);
 let ciphertext = result.ciphertext;
 let capsule = result.capsule;
 
@@ -56,7 +55,7 @@ console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() fai
 let n = 3; // how many fragments to create
 let m = 2; // how many should be enough to decrypt
 let kfrags = umbral.generate_kfrags(
-    params, alice_sk, bob_pk, signing_sk, m, n, true, true);
+    alice_sk, bob_pk, signing_sk, m, n, true, true);
 
 // Bob asks several Ursulas to re-encrypt the capsule so he can open it.
 // Each Ursula performs re-encryption on the capsule using the kfrag provided by Alice,

--- a/umbral-pre-wasm/example/index.js
+++ b/umbral-pre-wasm/example/index.js
@@ -59,19 +59,19 @@ let kfrags = umbral.generate_kfrags(
 // Ursulas can optionally check that the received kfrags are valid
 // and perform the reencryption
 
-let metadata = "asbdasdasd";
-
 // Ursula 0
+let metadata0 = enc.encode("metadata0")
 console.assert(
     kfrags[0].verify_with_delegating_and_receiving_keys(signing_pk, alice_pk, bob_pk),
     "kfrag0 is invalid");
-let cfrag0 = umbral.reencrypt(capsule, kfrags[0], enc.encode(metadata));
+let cfrag0 = umbral.reencrypt(capsule, kfrags[0], metadata0);
 
 // Ursula 1
+let metadata1 = enc.encode("metadata1");
 console.assert(
     kfrags[1].verify_with_delegating_and_receiving_keys(signing_pk, alice_pk, bob_pk),
     "kfrag1 is invalid");
-let cfrag1 = umbral.reencrypt(capsule, kfrags[1], enc.encode(metadata));
+let cfrag1 = umbral.reencrypt(capsule, kfrags[1], metadata1);
 
 // ...
 
@@ -79,8 +79,8 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1], enc.encode(metadata));
 // and then decrypts the re-encrypted ciphertext.
 
 // Bob can optionally check that cfrags are valid
-console.assert(cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk), "cfrag0 is invalid");
-console.assert(cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk), "cfrag1 is invalid");
+console.assert(cfrag0.verify(capsule, alice_pk, bob_pk, signing_pk, metadata0), "cfrag0 is invalid");
+console.assert(cfrag1.verify(capsule, alice_pk, bob_pk, signing_pk, metadata1), "cfrag1 is invalid");
 
 // Another deviation from the Rust API.
 // wasm-pack does not support taking arrays as arguments,

--- a/umbral-pre-wasm/example/index.js
+++ b/umbral-pre-wasm/example/index.js
@@ -21,14 +21,13 @@ let bob_pk = umbral.PublicKey.from_secret_key(bob_sk);
 // Invocation of `encrypt()` returns both the ciphertext and a capsule.
 // Note that anyone with Alice's public key can perform this operation.
 
-let params = new umbral.Parameters();
 let plaintext = "Plaintext message";
 let plaintext_bytes = enc.encode(plaintext);
 
 // The API here slightly differs from that in Rust.
 // Since wasm-pack does not support returning tuples, we return an object containing
 // the ciphertext and the capsule.
-let result = umbral.encrypt(params, alice_pk, plaintext_bytes);
+let result = umbral.encrypt(alice_pk, plaintext_bytes);
 let ciphertext = result.ciphertext;
 let capsule = result.capsule;
 
@@ -45,7 +44,7 @@ console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() fai
 let n = 3; // how many fragments to create
 let m = 2; // how many should be enough to decrypt
 let kfrags = umbral.generate_kfrags(
-    params, alice_sk, bob_pk, signing_sk, m, n,
+    alice_sk, bob_pk, signing_sk, m, n,
     true, // add the delegating key (alice_pk) to the signature
     true, // add the receiving key (bob_pk) to the signature
     );

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -36,23 +36,6 @@ impl PublicKey {
 }
 
 #[wasm_bindgen]
-pub struct Parameters(umbral_pre::Parameters);
-
-#[wasm_bindgen]
-impl Parameters {
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Self {
-        Self(umbral_pre::Parameters::new())
-    }
-}
-
-impl Default for Parameters {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[wasm_bindgen]
 #[derive(Clone, Copy)]
 pub struct Capsule(umbral_pre::Capsule);
 
@@ -154,15 +137,9 @@ impl EncryptionResult {
 }
 
 #[wasm_bindgen]
-pub fn encrypt(
-    params: &Parameters,
-    alice_pubkey: &PublicKey,
-    plaintext: &[u8],
-) -> Option<EncryptionResult> {
-    let backend_params = params.0;
+pub fn encrypt(alice_pubkey: &PublicKey, plaintext: &[u8]) -> Option<EncryptionResult> {
     let backend_pubkey = alice_pubkey.0;
-    let (capsule, ciphertext) =
-        umbral_pre::encrypt(&backend_params, &backend_pubkey, plaintext).unwrap();
+    let (capsule, ciphertext) = umbral_pre::encrypt(&backend_pubkey, plaintext).unwrap();
     Some(EncryptionResult::new(ciphertext, Capsule(capsule)))
 }
 
@@ -234,7 +211,6 @@ impl KeyFrag {
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
 pub fn generate_kfrags(
-    params: &Parameters,
     delegating_sk: &SecretKey,
     receiving_pubkey: &PublicKey,
     signing_sk: &SecretKey,
@@ -244,7 +220,6 @@ pub fn generate_kfrags(
     sign_receiving_key: bool,
 ) -> Vec<JsValue> {
     let backend_kfrags = umbral_pre::generate_kfrags(
-        &params.0,
         &delegating_sk.0,
         &receiving_pubkey.0,
         &signing_sk.0,

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -66,12 +66,16 @@ impl CapsuleFrag {
         signing_pubkey: &PublicKey,
         delegating_pubkey: &PublicKey,
         receiving_pubkey: &PublicKey,
+        metadata: Option<Box<[u8]>>,
     ) -> bool {
+        // feels like there should be a better way...
+        let metadata_ref: Option<&[u8]> = metadata.as_ref().map(|s| s.as_ref());
         self.0.verify(
             &capsule.0,
             &signing_pubkey.0,
             &delegating_pubkey.0,
             &receiving_pubkey.0,
+            metadata_ref,
         )
     }
 }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 k256 = { version = "0.7", default-features = false, features = ["ecdsa", "arithmetic"] }
 sha2 = "0.9"
-chacha20poly1305 = "0.7"
+chacha20poly1305 = { version = "0.7", features = ["xchacha20poly1305"] }
 hkdf = "0.10"
 
 # These packages are among the dependencies of the packages above.

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -24,7 +24,7 @@ aead = { version = "0.3", features = ["heapless"] }
 ecdsa = "0.10"
 signature = "1.2"
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
-typenum = "1.12"
+typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.1", default-features = false, features = ["wasm-bindgen"] }
 subtle = { version = "2.4", default-features = false }
 

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -19,44 +19,45 @@ pub struct Capsule {
     pub(crate) signature: CurveScalar,
 }
 
-type ParametersSize = <Parameters as SerializableToArray>::Size;
 type PointSize = <CurvePoint as SerializableToArray>::Size;
 type ScalarSize = <CurveScalar as SerializableToArray>::Size;
-type CapsuleSize = op!(ParametersSize + PointSize + PointSize + ScalarSize);
+type CapsuleSize = op!(PointSize + PointSize + ScalarSize);
 
 impl SerializableToArray for Capsule {
     type Size = CapsuleSize;
 
     fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        self.params
+        self.point_e
             .to_array()
-            .concat(self.point_e.to_array())
             .concat(self.point_v.to_array())
             .concat(self.signature.to_array())
     }
 
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        let (params, rest) = Parameters::take(*arr)?;
-        let (point_e, rest) = CurvePoint::take(rest)?;
+        let (point_e, rest) = CurvePoint::take(*arr)?;
         let (point_v, rest) = CurvePoint::take(rest)?;
         let signature = CurveScalar::take_last(rest)?;
-        Self::new_verified(params, point_e, point_v, signature)
+        Self::new_verified(point_e, point_v, signature)
     }
 }
 
 impl Capsule {
-    pub(crate) fn new_verified(
-        params: Parameters,
-        point_e: CurvePoint,
-        point_v: CurvePoint,
-        signature: CurveScalar,
-    ) -> Option<Self> {
-        let capsule = Self {
+    fn new(point_e: CurvePoint, point_v: CurvePoint, signature: CurveScalar) -> Self {
+        let params = Parameters::new();
+        Self {
             params,
             point_e,
             point_v,
             signature,
-        };
+        }
+    }
+
+    pub(crate) fn new_verified(
+        point_e: CurvePoint,
+        point_v: CurvePoint,
+        signature: CurveScalar,
+    ) -> Option<Self> {
+        let capsule = Self::new(point_e, point_v, signature);
         match capsule.verify() {
             false => None,
             true => Some(capsule),
@@ -71,7 +72,7 @@ impl Capsule {
     }
 
     /// Generates a symmetric key and its associated KEM ciphertext
-    pub(crate) fn from_pubkey(params: &Parameters, pk: &PublicKey) -> (Capsule, CurvePoint) {
+    pub(crate) fn from_pubkey(pk: &PublicKey) -> (Capsule, CurvePoint) {
         let g = CurvePoint::generator();
 
         let priv_r = CurveScalar::random_nonzero();
@@ -86,12 +87,7 @@ impl Capsule {
 
         let shared_key = &pk.to_point() * &(&priv_r + &priv_u);
 
-        let capsule = Self {
-            params: *params,
-            point_e: pub_r,
-            point_v: pub_u,
-            signature: s,
-        };
+        let capsule = Self::new(pub_r, pub_u, s);
 
         (capsule, shared_key)
     }
@@ -182,19 +178,16 @@ mod tests {
 
     use super::Capsule;
     use crate::{
-        encrypt, generate_kfrags, reencrypt, CapsuleFrag, Parameters, PublicKey, SecretKey,
-        SerializableToArray,
+        encrypt, generate_kfrags, reencrypt, CapsuleFrag, PublicKey, SecretKey, SerializableToArray,
     };
 
     #[test]
     fn test_serialize() {
-        let params = Parameters::new();
-
         let delegating_sk = SecretKey::random();
         let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
 
         let plaintext = b"peace at dawn";
-        let (capsule, _ciphertext) = encrypt(&params, &delegating_pk, plaintext).unwrap();
+        let (capsule, _ciphertext) = encrypt(&delegating_pk, plaintext).unwrap();
 
         let capsule_arr = capsule.to_array();
         let capsule_back = Capsule::from_array(&capsule_arr).unwrap();
@@ -203,8 +196,6 @@ mod tests {
 
     #[test]
     fn test_open_reencrypted() {
-        let params = Parameters::new();
-
         let delegating_sk = SecretKey::random();
         let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
 
@@ -213,18 +204,9 @@ mod tests {
         let receiving_sk = SecretKey::random();
         let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
 
-        let (capsule, key_seed) = Capsule::from_pubkey(&params, &delegating_pk);
+        let (capsule, key_seed) = Capsule::from_pubkey(&delegating_pk);
 
-        let kfrags = generate_kfrags(
-            &params,
-            &delegating_sk,
-            &receiving_pk,
-            &signing_sk,
-            2,
-            3,
-            true,
-            true,
-        );
+        let kfrags = generate_kfrags(&delegating_sk, &receiving_pk, &signing_sk, 2, 3, true, true);
 
         let cfrags: Vec<CapsuleFrag> = kfrags
             .iter()
@@ -242,16 +224,7 @@ mod tests {
             .is_none());
 
         // Mismatched cfrags - each `generate_kfrags()` uses new randoms.
-        let kfrags2 = generate_kfrags(
-            &params,
-            &delegating_sk,
-            &receiving_pk,
-            &signing_sk,
-            2,
-            3,
-            true,
-            true,
-        );
+        let kfrags2 = generate_kfrags(&delegating_sk, &receiving_pk, &signing_sk, 2, 3, true, true);
 
         let cfrags2: Vec<CapsuleFrag> = kfrags2
             .iter()
@@ -268,7 +241,7 @@ mod tests {
             .is_none());
 
         // Mismatched capsule
-        let (capsule2, _key_seed) = Capsule::from_pubkey(&params, &delegating_pk);
+        let (capsule2, _key_seed) = Capsule::from_pubkey(&delegating_pk);
         assert!(capsule2
             .open_reencrypted(&receiving_sk, &delegating_pk, &cfrags)
             .is_none());

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -1,6 +1,7 @@
 use crate::capsule_frag::CapsuleFrag;
-use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey};
+use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing_ds::{hash_capsule_points, hash_to_polynomial_arg, hash_to_shared_secret};
+use crate::keys::{PublicKey, SecretKey};
 use crate::params::Parameters;
 use crate::traits::SerializableToArray;
 

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -73,7 +73,7 @@ impl Capsule {
     }
 
     /// Generates a symmetric key and its associated KEM ciphertext
-    pub(crate) fn from_pubkey(pk: &PublicKey) -> (Capsule, CurvePoint) {
+    pub(crate) fn from_public_key(pk: &PublicKey) -> (Capsule, CurvePoint) {
         let g = CurvePoint::generator();
 
         let priv_r = CurveScalar::random_nonzero();
@@ -205,7 +205,7 @@ mod tests {
         let receiving_sk = SecretKey::random();
         let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
 
-        let (capsule, key_seed) = Capsule::from_pubkey(&delegating_pk);
+        let (capsule, key_seed) = Capsule::from_public_key(&delegating_pk);
 
         let kfrags = generate_kfrags(&delegating_sk, &receiving_pk, &signing_sk, 2, 3, true, true);
 
@@ -242,7 +242,7 @@ mod tests {
             .is_none());
 
         // Mismatched capsule
-        let (capsule2, _key_seed) = Capsule::from_pubkey(&delegating_pk);
+        let (capsule2, _key_seed) = Capsule::from_public_key(&delegating_pk);
         assert!(capsule2
             .open_reencrypted(&receiving_sk, &delegating_pk, &cfrags)
             .is_none());

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -1,8 +1,8 @@
 use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
-use crate::curve::{PublicKey, Signature};
 use crate::hashing_ds::{hash_to_cfrag_signature, hash_to_cfrag_verification};
 use crate::key_frag::{KeyFrag, KeyFragID};
+use crate::keys::{PublicKey, Signature};
 use crate::traits::SerializableToArray;
 
 use generic_array::sequence::Concat;

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -264,13 +264,10 @@ mod tests {
 
     use super::CapsuleFrag;
     use crate::{
-        encrypt, generate_kfrags, reencrypt, Capsule, Parameters, PublicKey, SecretKey,
-        SerializableToArray,
+        encrypt, generate_kfrags, reencrypt, Capsule, PublicKey, SecretKey, SerializableToArray,
     };
 
     fn prepare_cfrags() -> (PublicKey, PublicKey, PublicKey, Capsule, Box<[CapsuleFrag]>) {
-        let params = Parameters::new();
-
         let delegating_sk = SecretKey::random();
         let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
 
@@ -281,18 +278,9 @@ mod tests {
         let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
 
         let plaintext = b"peace at dawn";
-        let (capsule, _ciphertext) = encrypt(&params, &delegating_pk, plaintext).unwrap();
+        let (capsule, _ciphertext) = encrypt(&delegating_pk, plaintext).unwrap();
 
-        let kfrags = generate_kfrags(
-            &params,
-            &delegating_sk,
-            &receiving_pk,
-            &signing_sk,
-            2,
-            3,
-            true,
-            true,
-        );
+        let kfrags = generate_kfrags(&delegating_sk, &receiving_pk, &signing_sk, 2, 3, true, true);
 
         let cfrags: Vec<CapsuleFrag> = kfrags
             .iter()

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -133,7 +133,7 @@ impl CapsuleFragProof {
             kfrag_commitment: u1,
             kfrag_pok: u2,
             signature: z3,
-            kfrag_signature: kfrag.proof.signature_for_bob(),
+            kfrag_signature: kfrag.proof.signature_for_receiver(),
             metadata: *metadata,
         }
     }

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -1,45 +1,13 @@
 use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::curve::{PublicKey, Signature};
-use crate::hashing_ds::{hash_metadata, hash_to_cfrag_signature, hash_to_cfrag_verification};
+use crate::hashing_ds::{hash_to_cfrag_signature, hash_to_cfrag_verification};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::traits::SerializableToArray;
 
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
-use typenum::{op, U32};
-
-// The compiler will ensure that's the array length we are getting from the hash function.
-// Hardcoding here for the purposes of the formal specification.
-type HashedMetadataSize = U32;
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct HashedMetadata(GenericArray<u8, HashedMetadataSize>);
-
-impl HashedMetadata {
-    fn new(maybe_metadata: Option<&[u8]>) -> Self {
-        let metadata = maybe_metadata.unwrap_or(b"");
-        Self(hash_metadata(metadata))
-    }
-}
-
-impl AsRef<[u8]> for HashedMetadata {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl SerializableToArray for HashedMetadata {
-    type Size = HashedMetadataSize;
-
-    fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        self.0
-    }
-
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        Some(Self(*arr))
-    }
-}
+use typenum::op;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CapsuleFragProof {
@@ -49,14 +17,13 @@ pub struct CapsuleFragProof {
     kfrag_pok: CurvePoint,
     signature: CurveScalar,
     kfrag_signature: Signature,
-    metadata: HashedMetadata,
 }
 
 type PointSize = <CurvePoint as SerializableToArray>::Size;
 type ScalarSize = <CurveScalar as SerializableToArray>::Size;
 type SignatureSize = <Signature as SerializableToArray>::Size;
 type CapsuleFragProofSize =
-    op!(PointSize + PointSize + PointSize + PointSize + ScalarSize + SignatureSize + ScalarSize);
+    op!(PointSize + PointSize + PointSize + PointSize + ScalarSize + SignatureSize);
 
 impl SerializableToArray for CapsuleFragProof {
     type Size = CapsuleFragProofSize;
@@ -69,7 +36,6 @@ impl SerializableToArray for CapsuleFragProof {
             .concat(self.kfrag_pok.to_array())
             .concat(self.signature.to_array())
             .concat(self.kfrag_signature.to_array())
-            .concat(self.metadata.to_array())
     }
 
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
@@ -78,8 +44,7 @@ impl SerializableToArray for CapsuleFragProof {
         let (kfrag_commitment, rest) = CurvePoint::take(rest)?;
         let (kfrag_pok, rest) = CurvePoint::take(rest)?;
         let (signature, rest) = CurveScalar::take(rest)?;
-        let (kfrag_signature, rest) = Signature::take(rest)?;
-        let metadata = HashedMetadata::take_last(rest)?;
+        let kfrag_signature = Signature::take_last(rest)?;
         Some(Self {
             point_e2,
             point_v2,
@@ -87,7 +52,6 @@ impl SerializableToArray for CapsuleFragProof {
             kfrag_pok,
             signature,
             kfrag_signature,
-            metadata,
         })
     }
 }
@@ -99,7 +63,7 @@ impl CapsuleFragProof {
         kfrag: &KeyFrag,
         cfrag_e1: &CurvePoint,
         cfrag_v1: &CurvePoint,
-        metadata: &HashedMetadata,
+        metadata: Option<&[u8]>,
     ) -> Self {
         let params = capsule.params;
 
@@ -134,7 +98,6 @@ impl CapsuleFragProof {
             kfrag_pok: u2,
             signature: z3,
             kfrag_signature: kfrag.proof.signature_for_receiver(),
-            metadata: *metadata,
         }
     }
 }
@@ -180,16 +143,11 @@ impl SerializableToArray for CapsuleFrag {
 }
 
 impl CapsuleFrag {
-    pub(crate) fn reencrypted(
-        capsule: &Capsule,
-        kfrag: &KeyFrag,
-        maybe_metadata: Option<&[u8]>,
-    ) -> Self {
+    pub(crate) fn reencrypted(capsule: &Capsule, kfrag: &KeyFrag, metadata: Option<&[u8]>) -> Self {
         let rk = kfrag.key;
         let e1 = &capsule.point_e * &rk;
         let v1 = &capsule.point_v * &rk;
-        let metadata = HashedMetadata::new(maybe_metadata);
-        let proof = CapsuleFragProof::from_kfrag_and_cfrag(&capsule, &kfrag, &e1, &v1, &metadata);
+        let proof = CapsuleFragProof::from_kfrag_and_cfrag(&capsule, &kfrag, &e1, &v1, metadata);
 
         Self {
             point_e1: e1,
@@ -208,6 +166,7 @@ impl CapsuleFrag {
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
         signing_pk: &PublicKey,
+        metadata: Option<&[u8]>,
     ) -> bool {
         let params = capsule.params;
 
@@ -227,8 +186,7 @@ impl CapsuleFrag {
         let v2 = self.proof.point_v2;
         let u2 = self.proof.kfrag_pok;
 
-        let h =
-            hash_to_cfrag_verification(&[e, e1, e2, v, v1, v2, u, u1, u2], &self.proof.metadata);
+        let h = hash_to_cfrag_verification(&[e, e1, e2, v, v1, v2, u, u1, u2], metadata);
 
         ///////
 
@@ -267,7 +225,14 @@ mod tests {
         encrypt, generate_kfrags, reencrypt, Capsule, PublicKey, SecretKey, SerializableToArray,
     };
 
-    fn prepare_cfrags() -> (PublicKey, PublicKey, PublicKey, Capsule, Box<[CapsuleFrag]>) {
+    fn prepare_cfrags() -> (
+        PublicKey,
+        PublicKey,
+        PublicKey,
+        Capsule,
+        Box<[CapsuleFrag]>,
+        Box<[u8]>,
+    ) {
         let delegating_sk = SecretKey::random();
         let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
 
@@ -282,9 +247,10 @@ mod tests {
 
         let kfrags = generate_kfrags(&delegating_sk, &receiving_pk, &signing_sk, 2, 3, true, true);
 
+        let metadata = b"metadata";
         let cfrags: Vec<CapsuleFrag> = kfrags
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag, None))
+            .map(|kfrag| reencrypt(&capsule, &kfrag, Some(metadata)))
             .collect();
 
         (
@@ -293,12 +259,13 @@ mod tests {
             signing_pk,
             capsule,
             cfrags.into_boxed_slice(),
+            Box::new(*metadata),
         )
     }
 
     #[test]
     fn test_serialize() {
-        let (_, _, _, _, cfrags) = prepare_cfrags();
+        let (_, _, _, _, cfrags, _) = prepare_cfrags();
         let cfrag_arr = cfrags[0].to_array();
         let cfrag_back = CapsuleFrag::from_array(&cfrag_arr).unwrap();
         assert_eq!(cfrags[0], cfrag_back);
@@ -306,12 +273,13 @@ mod tests {
 
     #[test]
     fn test_verify() {
-        let (delegating_pk, receiving_pk, signing_pk, capsule, cfrags) = prepare_cfrags();
+        let (delegating_pk, receiving_pk, signing_pk, capsule, cfrags, metadata) = prepare_cfrags();
         assert!(cfrags.iter().all(|cfrag| cfrag.verify(
             &capsule,
             &delegating_pk,
             &receiving_pk,
             &signing_pk,
+            Some(&metadata)
         )));
     }
 }

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -167,6 +167,8 @@ impl SerializableToArray for Signature {
     }
 
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
+        // Note that it will not normalize `s` automatically,
+        // and if it is not normalized, verification will fail.
         BackendSignature::<CurveType>::from_bytes(arr.as_slice())
             .ok()
             .map(Self)

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -19,7 +19,7 @@ use crate::traits::SerializableToArray;
 pub(crate) type CurveType = Secp256k1;
 
 type BackendScalar = Scalar<CurveType>;
-type BackendNonZeroScalar = NonZeroScalar<CurveType>;
+pub(crate) type BackendNonZeroScalar = NonZeroScalar<CurveType>;
 
 // We have to define newtypes for scalar and point here because the compiler
 // is not currently smart enough to resolve `BackendScalar` and `BackendPoint`
@@ -35,6 +35,10 @@ pub struct CurveScalar(BackendScalar);
 impl CurveScalar {
     pub(crate) fn from_backend_scalar(scalar: &BackendScalar) -> Self {
         Self(*scalar)
+    }
+
+    pub(crate) fn to_backend_scalar(&self) -> BackendScalar {
+        self.0
     }
 
     pub(crate) fn invert(&self) -> CtOption<Self> {

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -4,25 +4,19 @@
 
 use core::default::Default;
 use core::ops::{Add, Mul, Sub};
-use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
-use ecdsa::{Signature as BackendSignature, SignatureSize, SigningKey, VerifyingKey};
+use digest::Digest;
 use elliptic_curve::ff::PrimeField;
 use elliptic_curve::scalar::NonZeroScalar;
 use elliptic_curve::sec1::{CompressedPointSize, EncodedPoint, FromEncodedPoint, ToEncodedPoint};
-use elliptic_curve::{
-    Curve, FromDigest, ProjectiveArithmetic, PublicKey as BackendPublicKey, Scalar,
-    SecretKey as BackendSecretKey,
-};
-use generic_array::typenum::U32;
+use elliptic_curve::{AffinePoint, Curve, FromDigest, ProjectiveArithmetic, Scalar};
 use generic_array::GenericArray;
 use k256::Secp256k1;
 use rand_core::OsRng;
-use signature::{DigestVerifier, RandomizedDigestSigner, Signature as SignatureTrait};
 use subtle::CtOption;
 
 use crate::traits::SerializableToArray;
 
-type CurveType = Secp256k1;
+pub(crate) type CurveType = Secp256k1;
 
 type BackendScalar = Scalar<CurveType>;
 type BackendNonZeroScalar = NonZeroScalar<CurveType>;
@@ -39,6 +33,10 @@ type BackendNonZeroScalar = NonZeroScalar<CurveType>;
 pub struct CurveScalar(BackendScalar);
 
 impl CurveScalar {
+    pub(crate) fn from_backend_scalar(scalar: &BackendScalar) -> Self {
+        Self(*scalar)
+    }
+
     pub(crate) fn invert(&self) -> CtOption<Self> {
         self.0.invert().map(Self)
     }
@@ -84,17 +82,26 @@ impl SerializableToArray for CurveScalar {
 }
 
 type BackendPoint = <CurveType as ProjectiveArithmetic>::ProjectivePoint;
+type BackendPointAffine = AffinePoint<CurveType>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CurvePoint(BackendPoint);
 
 impl CurvePoint {
+    pub(crate) fn from_backend_point(point: &BackendPoint) -> Self {
+        Self(*point)
+    }
+
     pub(crate) fn generator() -> Self {
         Self(BackendPoint::generator())
     }
 
     pub(crate) fn identity() -> Self {
         Self(BackendPoint::identity())
+    }
+
+    pub(crate) fn to_affine(&self) -> BackendPointAffine {
+        self.0.to_affine()
     }
 }
 
@@ -153,156 +160,5 @@ impl SerializableToArray for CurvePoint {
         let ep = EncodedPoint::<CurveType>::from_bytes(arr.as_slice()).ok()?;
         let cp_opt: Option<BackendPoint> = BackendPoint::from_encoded_point(&ep);
         cp_opt.map(Self)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Signature(BackendSignature<CurveType>);
-
-impl SerializableToArray for Signature {
-    type Size = SignatureSize<CurveType>;
-
-    fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        *GenericArray::<u8, Self::Size>::from_slice(self.0.as_bytes())
-    }
-
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        // Note that it will not normalize `s` automatically,
-        // and if it is not normalized, verification will fail.
-        BackendSignature::<CurveType>::from_bytes(arr.as_slice())
-            .ok()
-            .map(Self)
-    }
-}
-
-/// A secret key.
-#[derive(Clone)] // No Debug derivation, to avoid exposing the key accidentally.
-pub struct SecretKey(BackendSecretKey<CurveType>);
-
-impl PartialEq for SecretKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_secret_scalar() == other.to_secret_scalar()
-    }
-}
-
-impl SecretKey {
-    /// Generates a secret key using the default RNG and returns it.
-    pub fn random() -> Self {
-        let secret_key = BackendSecretKey::<CurveType>::random(&mut OsRng);
-        Self(secret_key)
-    }
-
-    /// Returns a reference to the underlying scalar of the secret key.
-    pub(crate) fn to_secret_scalar(&self) -> CurveScalar {
-        // TODO (#8): `BackendSecretKey` only returns a reference,
-        // but how important is this safety measure?
-        // We could return a wrapped reference, and define arithmetic operations for it.
-        // But we use this secret scalar to multiply not only points, but other scalars too.
-        // So there's no point in hiding the actual value here as long as
-        // it is going to be effectively dereferenced in other places.
-        CurveScalar(**self.0.secret_scalar())
-    }
-
-    /// Signs a message using the default RNG.
-    pub(crate) fn sign_digest(
-        &self,
-        digest: impl BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
-    ) -> Signature {
-        let signer = SigningKey::<CurveType>::from(self.0.clone());
-        Signature(signer.sign_digest_with_rng(OsRng, digest))
-    }
-}
-
-impl SerializableToArray for SecretKey {
-    type Size = <CurveScalar as SerializableToArray>::Size;
-
-    fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        // TODO (#8): a copy of secret data is created in `to_bytes()`.
-        self.0.to_bytes()
-    }
-
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        BackendSecretKey::<CurveType>::from_bytes(arr.as_slice())
-            .ok()
-            .map(Self)
-    }
-}
-
-/// A public key.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct PublicKey(BackendPublicKey<CurveType>);
-
-impl PublicKey {
-    /// Creates a public key from a secret key.
-    pub fn from_secret_key(secret_key: &SecretKey) -> Self {
-        Self(secret_key.0.public_key())
-    }
-
-    /// Returns the underlying curve point of the public key.
-    pub(crate) fn to_point(&self) -> CurvePoint {
-        CurvePoint(self.0.to_projective())
-    }
-
-    /// Verifies the signature.
-    pub(crate) fn verify_digest(
-        &self,
-        digest: impl Digest<OutputSize = U32>,
-        signature: &Signature,
-    ) -> bool {
-        let verifier = VerifyingKey::from(&self.0);
-        verifier.verify_digest(digest, &signature.0).is_ok()
-    }
-}
-
-impl SerializableToArray for PublicKey {
-    type Size = <CurvePoint as SerializableToArray>::Size;
-
-    fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        self.to_point().to_array()
-    }
-
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        let cp = CurvePoint::from_array(&arr)?;
-        let backend_pk = BackendPublicKey::<CurveType>::from_affine(cp.0.to_affine()).ok()?;
-        Some(Self(backend_pk))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use sha2::Sha256;
-    use signature::digest::Digest;
-
-    use super::{PublicKey, SecretKey};
-    use crate::SerializableToArray;
-
-    #[test]
-    fn test_serialize_secret_key() {
-        let sk = SecretKey::random();
-        let sk_arr = sk.to_array();
-        let sk_back = SecretKey::from_array(&sk_arr).unwrap();
-        assert_eq!(sk.to_secret_scalar(), sk_back.to_secret_scalar());
-    }
-
-    #[test]
-    fn test_serialize_public_key() {
-        let sk = SecretKey::random();
-        let pk = PublicKey::from_secret_key(&sk);
-        let pk_arr = pk.to_array();
-        let pk_back = PublicKey::from_array(&pk_arr).unwrap();
-        assert_eq!(pk, pk_back);
-    }
-
-    #[test]
-    fn test_sign_and_verify() {
-        let sk = SecretKey::random();
-        let message = b"asdafdahsfdasdfasd";
-        let digest = Sha256::new().chain(message);
-        let signature = sk.sign_digest(digest);
-
-        let pk = PublicKey::from_secret_key(&sk);
-        let digest = Sha256::new().chain(message);
-        assert!(pk.verify_digest(digest, &signature));
     }
 }

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -174,7 +174,7 @@ impl SerializableToArray for Signature {
 }
 
 /// A secret key.
-#[derive(Clone, Debug)]
+#[derive(Clone)] // No Debug derivation, to avoid exposing the key accidentally.
 pub struct SecretKey(BackendSecretKey<CurveType>);
 
 impl PartialEq for SecretKey {
@@ -215,6 +215,7 @@ impl SerializableToArray for SecretKey {
     type Size = <CurveScalar as SerializableToArray>::Size;
 
     fn to_array(&self) -> GenericArray<u8, Self::Size> {
+        // TODO (#8): a copy of secret data is created in `to_bytes()`.
         self.0.to_bytes()
     }
 
@@ -279,7 +280,7 @@ mod tests {
         let sk = SecretKey::random();
         let sk_arr = sk.to_array();
         let sk_back = SecretKey::from_array(&sk_arr).unwrap();
-        assert_eq!(sk, sk_back);
+        assert_eq!(sk.to_secret_scalar(), sk_back.to_secret_scalar());
     }
 
     #[test]

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -31,8 +31,8 @@ pub(crate) struct DEM {
 }
 
 impl DEM {
-    pub fn new(key_seed: &[u8]) -> Self {
-        let key_bytes = kdf(&key_seed, None, None);
+    pub fn new(key_seed: &[u8], salt: Option<&[u8]>, info: Option<&[u8]>) -> Self {
+        let key_bytes = kdf(&key_seed, salt, info);
         let key = Key::from_slice(&key_bytes);
         let cipher = XChaCha20Poly1305::new(key);
         Self { cipher }

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -26,11 +26,11 @@ fn kdf(seed: &[u8], salt: Option<&[u8]>, info: Option<&[u8]>) -> GenericArray<u8
 
 type NonceSize = <XChaCha20Poly1305 as AeadInPlace>::NonceSize;
 
-pub(crate) struct UmbralDEM {
+pub(crate) struct DEM {
     cipher: XChaCha20Poly1305,
 }
 
-impl UmbralDEM {
+impl DEM {
     pub fn new(key_seed: &[u8]) -> Self {
         let key_bytes = kdf(&key_seed, None, None);
         let key = Key::from_slice(&key_bytes);

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -34,9 +34,9 @@ pub(crate) struct DEM {
 }
 
 impl DEM {
-    pub fn new(key_seed: &[u8], salt: Option<&[u8]>, info: Option<&[u8]>) -> Self {
+    pub fn new(key_seed: &[u8]) -> Self {
         type KeySize = <XChaCha20Poly1305 as NewAead>::KeySize;
-        let key_bytes = kdf::<KeySize>(&key_seed, salt, info);
+        let key_bytes = kdf::<KeySize>(&key_seed, None, None);
         let key = Key::from_slice(&key_bytes);
         let cipher = XChaCha20Poly1305::new(key);
         Self { cipher }

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -24,7 +24,6 @@ pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
     // and it is always the same.
     let sign_prefix = GenericArray::<u8, U1>::from_slice(&[2u8]);
 
-    let dst_len = (dst.len() as u32).to_be_bytes();
     let data_len = (data.len() as u32).to_be_bytes();
 
     // We use an internal 32-bit counter as additional input
@@ -32,13 +31,11 @@ pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
     while i < <u32>::MAX {
         let ibytes = (i as u32).to_be_bytes();
 
-        let mut digest = Sha256::new();
-        digest.update(&dst_len);
-        digest.update(dst);
-        digest.update(&data_len);
-        digest.update(data);
-        digest.update(&ibytes);
-        let result = digest.finalize();
+        let result = BytesDigest::new_with_dst(dst)
+            .chain_bytes(&data_len)
+            .chain_bytes(data)
+            .chain_bytes(&ibytes)
+            .finalize();
 
         // Set the sign byte
         let maybe_point_bytes = sign_prefix.concat(result);
@@ -56,27 +53,40 @@ pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
     None
 }
 
-pub(crate) struct ScalarDigest(Sha256);
+// Wraps Sha256 for easier replacement, and standardizes the use of DST.
+struct Hash(Sha256);
 
-impl ScalarDigest {
-    pub fn new() -> Self {
-        Self(Sha256::new())
-    }
+// Can't be put in the `impl` in the current version of Rust.
+pub type HashOutputSize = <Sha256 as Digest>::OutputSize;
 
-    pub fn new_with_dst(bytes: &[u8]) -> Self {
-        Self::new().chain_bytes(bytes)
-    }
-
-    fn chain_impl(self, bytes: &[u8]) -> Self {
-        Self(digest::Digest::chain(self.0, bytes))
+impl Hash {
+    pub fn new_with_dst(dst: &[u8]) -> Self {
+        let dst_len = (dst.len() as u32).to_be_bytes();
+        Self(Sha256::new()).chain_bytes(dst_len).chain_bytes(dst)
     }
 
     pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
-        self.chain_impl(bytes.as_ref())
+        Self(digest::Digest::chain(self.0, bytes.as_ref()))
+    }
+
+    pub fn digest(self) -> Sha256 {
+        self.0
+    }
+}
+
+pub(crate) struct ScalarDigest(Hash);
+
+impl ScalarDigest {
+    pub fn new_with_dst(dst: &[u8]) -> Self {
+        Self(Hash::new_with_dst(dst))
+    }
+
+    pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
+        Self(self.0.chain_bytes(bytes))
     }
 
     pub fn chain_point(self, point: &CurvePoint) -> Self {
-        self.chain_impl(&point.to_array())
+        self.chain_bytes(&point.to_array())
     }
 
     pub fn chain_points(self, points: &[CurvePoint]) -> Self {
@@ -89,79 +99,64 @@ impl ScalarDigest {
 
     pub fn finalize(self) -> CurveScalar {
         // TODO (#35): use the standard method when it is available in RustCrypto.
-        CurveScalar::from_digest(self.0)
+        // TODO (#39): Ideally this should return a non-zero scalar.
+        //     (when it does, the loop in `KeyFragFactory::new()` can be removed)
+        CurveScalar::from_digest(self.0.digest())
     }
 }
 
-pub(crate) struct SignatureDigest(Sha256);
+pub(crate) struct SignatureDigest(Hash);
 
 impl SignatureDigest {
-    pub fn new() -> Self {
-        Self(Sha256::new())
-    }
-
-    fn chain_impl(self, bytes: &[u8]) -> Self {
-        Self(digest::Digest::chain(self.0, bytes))
+    pub fn new_with_dst(dst: &[u8]) -> Self {
+        Self(Hash::new_with_dst(dst))
     }
 
     pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
-        self.chain_impl(bytes.as_ref())
+        Self(self.0.chain_bytes(bytes))
     }
 
     pub fn chain_point(self, point: &CurvePoint) -> Self {
-        self.chain_impl(&point.to_array())
+        self.chain_bytes(&point.to_array())
     }
 
     pub fn chain_pubkey(self, pk: &PublicKey) -> Self {
-        self.chain_impl(&pk.to_array())
+        self.chain_bytes(&pk.to_array())
     }
 
     pub fn chain_bool(self, val: bool) -> Self {
-        self.chain_impl(&[val as u8])
+        self.chain_bytes(&[val as u8])
     }
 
     pub fn sign(self, sk: &SecretKey) -> Signature {
-        sk.sign_digest(self.0)
+        sk.sign_digest(self.0.digest())
     }
 
     pub fn verify(self, pk: &PublicKey, signature: &Signature) -> bool {
-        pk.verify_digest(self.0, signature)
+        pk.verify_digest(self.0.digest(), signature)
     }
 }
 
-pub(crate) struct BytesDigest(Sha256);
-
-// Can't be put in the `impl` in the current version of Rust.
-pub type BytesDigestOutputSize = <Sha256 as Digest>::OutputSize;
+pub(crate) struct BytesDigest(Hash);
 
 impl BytesDigest {
-    fn new() -> Self {
-        Self(Sha256::new())
+    pub fn new_with_dst(dst: &[u8]) -> Self {
+        Self(Hash::new_with_dst(dst))
     }
 
-    pub fn new_with_dst(bytes: &[u8]) -> Self {
-        Self::new().chain_bytes(bytes)
+    pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
+        Self(self.0.chain_bytes(bytes))
     }
 
-    fn chain_impl(self, bytes: &[u8]) -> Self {
-        Self(digest::Digest::chain(self.0, bytes))
-    }
-
-    pub fn chain_bytes(self, bytes: &[u8]) -> Self {
-        self.chain_impl(bytes)
-    }
-
-    pub fn finalize(self) -> GenericArray<u8, BytesDigestOutputSize> {
-        self.0.finalize()
+    pub fn finalize(self) -> GenericArray<u8, HashOutputSize> {
+        self.0.digest().finalize()
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use super::{
-        unsafe_hash_to_point, BytesDigest, BytesDigestOutputSize, ScalarDigest, SignatureDigest,
-    };
+    use super::{unsafe_hash_to_point, BytesDigest, HashOutputSize, ScalarDigest, SignatureDigest};
     use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
     use generic_array::GenericArray;
 
@@ -188,21 +183,27 @@ mod tests {
         let p2 = &p1 + &p1;
         let bytes: &[u8] = b"foobar";
 
-        let s: CurveScalar = ScalarDigest::new()
+        let s: CurveScalar = ScalarDigest::new_with_dst(b"abc")
             .chain_points(&[p1, p2])
             .chain_bytes(bytes)
             .finalize();
-        let s_same: CurveScalar = ScalarDigest::new()
+        let s_same: CurveScalar = ScalarDigest::new_with_dst(b"abc")
             .chain_points(&[p1, p2])
             .chain_bytes(bytes)
             .finalize();
         assert_eq!(s, s_same);
 
-        let s_diff: CurveScalar = ScalarDigest::new()
+        let s_diff: CurveScalar = ScalarDigest::new_with_dst(b"abc")
             .chain_points(&[p2, p1])
             .chain_bytes(bytes)
             .finalize();
         assert_ne!(s, s_diff);
+
+        let s_diff_tag: CurveScalar = ScalarDigest::new_with_dst(b"def")
+            .chain_points(&[p1, p2])
+            .chain_bytes(bytes)
+            .finalize();
+        assert_ne!(s, s_diff_tag);
     }
 
     #[test]
@@ -216,14 +217,14 @@ mod tests {
         let signing_sk = SecretKey::random();
         let signing_pk = PublicKey::from_secret_key(&signing_sk);
 
-        let signature: Signature = SignatureDigest::new()
+        let signature: Signature = SignatureDigest::new_with_dst(b"abc")
             .chain_point(&p2)
             .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .sign(&signing_sk);
 
-        let same_values_same_key = SignatureDigest::new()
+        let same_values_same_key = SignatureDigest::new_with_dst(b"abc")
             .chain_point(&p2)
             .chain_bytes(&bytes)
             .chain_bool(b)
@@ -231,23 +232,29 @@ mod tests {
             .verify(&signing_pk, &signature);
         assert!(same_values_same_key);
 
-        let same_values_different_key = SignatureDigest::new()
+        let same_values_different_key = SignatureDigest::new_with_dst(b"abc")
             .chain_point(&p2)
             .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .verify(&pk, &signature);
-
         assert!(!same_values_different_key);
 
-        let different_values_same_key = SignatureDigest::new()
+        let different_values_same_key = SignatureDigest::new_with_dst(b"abc")
             .chain_point(&p1)
             .chain_bytes(&bytes)
             .chain_bool(b)
             .chain_pubkey(&pk)
             .verify(&signing_pk, &signature);
-
         assert!(!different_values_same_key);
+
+        let same_values_different_tag = SignatureDigest::new_with_dst(b"def")
+            .chain_point(&p2)
+            .chain_bytes(&bytes)
+            .chain_bool(b)
+            .chain_pubkey(&pk)
+            .verify(&signing_pk, &signature);
+        assert!(!same_values_different_tag);
     }
 
     #[test]
@@ -255,14 +262,22 @@ mod tests {
         let bytes: &[u8] = b"foobar";
         let bytes2: &[u8] = b"barbaz";
 
-        let s: GenericArray<u8, BytesDigestOutputSize> =
-            BytesDigest::new().chain_bytes(bytes).finalize();
-        let s_same: GenericArray<u8, BytesDigestOutputSize> =
-            BytesDigest::new().chain_bytes(bytes).finalize();
+        let s: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
+            .chain_bytes(bytes)
+            .finalize();
+        let s_same: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
+            .chain_bytes(bytes)
+            .finalize();
         assert_eq!(s, s_same);
 
-        let s_diff: GenericArray<u8, BytesDigestOutputSize> =
-            BytesDigest::new().chain_bytes(bytes2).finalize();
+        let s_diff: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
+            .chain_bytes(bytes2)
+            .finalize();
         assert_ne!(s, s_diff);
+
+        let s_diff_tag: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"def")
+            .chain_bytes(bytes)
+            .finalize();
+        assert_ne!(s, s_diff_tag);
     }
 }

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -4,7 +4,8 @@ use generic_array::GenericArray;
 use sha2::Sha256;
 use typenum::U1;
 
-use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
+use crate::curve::{CurvePoint, CurveScalar};
+use crate::keys::{PublicKey, SecretKey, Signature};
 use crate::traits::SerializableToArray;
 
 /// Hashes arbitrary data with the given domain separation tag
@@ -157,7 +158,8 @@ impl BytesDigest {
 mod tests {
 
     use super::{unsafe_hash_to_point, BytesDigest, HashOutputSize, ScalarDigest, SignatureDigest};
-    use crate::curve::{CurvePoint, CurveScalar, PublicKey, SecretKey, Signature};
+    use crate::curve::{CurvePoint, CurveScalar};
+    use crate::keys::{PublicKey, SecretKey, Signature};
     use generic_array::GenericArray;
 
     #[test]

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -30,12 +30,10 @@ pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
     // We use an internal 32-bit counter as additional input
     let mut i = 0u32;
     while i < <u32>::MAX {
-        let ibytes = (i as u32).to_be_bytes();
-
         let result = BytesDigest::new_with_dst(dst)
             .chain_bytes(&data_len)
             .chain_bytes(data)
-            .chain_bytes(&ibytes)
+            .chain_bytes(&i.to_be_bytes())
             .finalize();
 
         // Set the sign byte
@@ -67,7 +65,7 @@ impl Hash {
     }
 
     pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
-        Self(digest::Digest::chain(self.0, bytes.as_ref()))
+        Self(self.0.chain(bytes.as_ref()))
     }
 
     pub fn digest(self) -> Sha256 {

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -1,9 +1,10 @@
 //! This module contains hashing sequences with included domain separation tags
 //! shared between different parts of the code.
 
-use crate::curve::{CurvePoint, CurveScalar, PublicKey};
+use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing::{ScalarDigest, SignatureDigest};
 use crate::key_frag::KeyFragID;
+use crate::keys::PublicKey;
 
 // TODO (#39): Ideally this should return a non-zero scalar.
 pub(crate) fn hash_to_polynomial_arg(

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -3,8 +3,9 @@
 
 use generic_array::GenericArray;
 
-use crate::curve::{CurvePoint, CurveScalar};
-use crate::hashing::{BytesDigest, BytesDigestOutputSize, ScalarDigest};
+use crate::capsule_frag::HashedMetadata;
+use crate::curve::{CurvePoint, CurveScalar, PublicKey};
+use crate::hashing::{BytesDigest, HashOutputSize, ScalarDigest, SignatureDigest};
 use crate::key_frag::KeyFragID;
 
 // TODO (#39): Ideally this should return a non-zero scalar.
@@ -22,8 +23,6 @@ pub(crate) fn hash_to_polynomial_arg(
         .finalize()
 }
 
-// TODO (#39): Ideally this should return a non-zero scalar.
-// (when it does, the loop in `KeyFragFactory::new()` can be removed)
 pub(crate) fn hash_to_shared_secret(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,
@@ -36,8 +35,51 @@ pub(crate) fn hash_to_shared_secret(
         .finalize()
 }
 
-pub(crate) fn hash_metadata(bytes: &[u8]) -> GenericArray<u8, BytesDigestOutputSize> {
+pub(crate) fn hash_metadata(bytes: &[u8]) -> GenericArray<u8, HashOutputSize> {
     BytesDigest::new_with_dst(b"METADATA")
         .chain_bytes(bytes)
         .finalize()
+}
+
+pub(crate) fn hash_capsule_points(capsule_e: &CurvePoint, capsule_v: &CurvePoint) -> CurveScalar {
+    ScalarDigest::new_with_dst(b"CAPSULE_POINTS")
+        .chain_point(capsule_e)
+        .chain_point(capsule_v)
+        .finalize()
+}
+
+pub(crate) fn hash_to_cfrag_verification(
+    points: &[CurvePoint],
+    metadata: &HashedMetadata,
+) -> CurveScalar {
+    ScalarDigest::new_with_dst(b"CFRAG_VERIFICATION")
+        .chain_points(points)
+        .chain_bytes(metadata)
+        .finalize()
+}
+
+pub(crate) fn hash_to_cfrag_signature(
+    kfrag_id: &KeyFragID,
+    commitment: &CurvePoint,
+    precursor: &CurvePoint,
+    maybe_delegating_pk: Option<&PublicKey>,
+    maybe_receiving_pk: Option<&PublicKey>,
+) -> SignatureDigest {
+    let digest = SignatureDigest::new_with_dst(b"CFRAG_SIGNATURE")
+        .chain_bytes(kfrag_id)
+        .chain_point(commitment)
+        .chain_point(precursor);
+
+    let digest = match maybe_delegating_pk {
+        Some(delegating_pk) => digest.chain_bool(true).chain_pubkey(delegating_pk),
+        None => digest.chain_bool(false),
+    };
+
+    #[allow(clippy::let_and_return)]
+    let digest = match maybe_receiving_pk {
+        Some(receiving_pk) => digest.chain_bool(true).chain_pubkey(receiving_pk),
+        None => digest.chain_bool(false),
+    };
+
+    digest
 }

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -1,6 +1,6 @@
 use crate::curve::{CurvePoint, CurveScalar};
-use crate::curve::{PublicKey, SecretKey, Signature};
 use crate::hashing_ds::{hash_to_cfrag_signature, hash_to_polynomial_arg, hash_to_shared_secret};
+use crate::keys::{PublicKey, SecretKey, Signature};
 use crate::params::Parameters;
 use crate::traits::SerializableToArray;
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -1,0 +1,161 @@
+use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
+use ecdsa::{Signature as BackendSignature, SignatureSize, SigningKey, VerifyingKey};
+use elliptic_curve::{PublicKey as BackendPublicKey, SecretKey as BackendSecretKey};
+use generic_array::GenericArray;
+use rand_core::OsRng;
+use signature::{DigestVerifier, RandomizedDigestSigner, Signature as SignatureTrait};
+use typenum::U32;
+
+use crate::curve::{CurvePoint, CurveScalar, CurveType};
+use crate::traits::SerializableToArray;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Signature(BackendSignature<CurveType>);
+
+impl SerializableToArray for Signature {
+    type Size = SignatureSize<CurveType>;
+
+    fn to_array(&self) -> GenericArray<u8, Self::Size> {
+        *GenericArray::<u8, Self::Size>::from_slice(self.0.as_bytes())
+    }
+
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
+        // Note that it will not normalize `s` automatically,
+        // and if it is not normalized, verification will fail.
+        BackendSignature::<CurveType>::from_bytes(arr.as_slice())
+            .ok()
+            .map(Self)
+    }
+}
+
+/// A secret key.
+#[derive(Clone)] // No Debug derivation, to avoid exposing the key accidentally.
+pub struct SecretKey(BackendSecretKey<CurveType>);
+
+impl PartialEq for SecretKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_secret_scalar() == other.to_secret_scalar()
+    }
+}
+
+impl SecretKey {
+    /// Generates a secret key using the default RNG and returns it.
+    pub fn random() -> Self {
+        let secret_key = BackendSecretKey::<CurveType>::random(&mut OsRng);
+        Self(secret_key)
+    }
+
+    /// Returns a reference to the underlying scalar of the secret key.
+    pub(crate) fn to_secret_scalar(&self) -> CurveScalar {
+        // TODO (#8): `BackendSecretKey` only returns a reference,
+        // but how important is this safety measure?
+        // We could return a wrapped reference, and define arithmetic operations for it.
+        // But we use this secret scalar to multiply not only points, but other scalars too.
+        // So there's no point in hiding the actual value here as long as
+        // it is going to be effectively dereferenced in other places.
+        CurveScalar::from_backend_scalar(&*self.0.secret_scalar())
+    }
+
+    /// Signs a message using the default RNG.
+    pub(crate) fn sign_digest(
+        &self,
+        digest: impl BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+    ) -> Signature {
+        let signer = SigningKey::<CurveType>::from(self.0.clone());
+        Signature(signer.sign_digest_with_rng(OsRng, digest))
+    }
+}
+
+impl SerializableToArray for SecretKey {
+    type Size = <CurveScalar as SerializableToArray>::Size;
+
+    fn to_array(&self) -> GenericArray<u8, Self::Size> {
+        // TODO (#8): a copy of secret data is created in `to_bytes()`.
+        self.0.to_bytes()
+    }
+
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
+        BackendSecretKey::<CurveType>::from_bytes(arr.as_slice())
+            .ok()
+            .map(Self)
+    }
+}
+
+/// A public key.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PublicKey(BackendPublicKey<CurveType>);
+
+impl PublicKey {
+    /// Creates a public key from a secret key.
+    pub fn from_secret_key(secret_key: &SecretKey) -> Self {
+        Self(secret_key.0.public_key())
+    }
+
+    /// Returns the underlying curve point of the public key.
+    pub(crate) fn to_point(&self) -> CurvePoint {
+        CurvePoint::from_backend_point(&self.0.to_projective())
+    }
+
+    /// Verifies the signature.
+    pub(crate) fn verify_digest(
+        &self,
+        digest: impl Digest<OutputSize = U32>,
+        signature: &Signature,
+    ) -> bool {
+        let verifier = VerifyingKey::from(&self.0);
+        verifier.verify_digest(digest, &signature.0).is_ok()
+    }
+}
+
+impl SerializableToArray for PublicKey {
+    type Size = <CurvePoint as SerializableToArray>::Size;
+
+    fn to_array(&self) -> GenericArray<u8, Self::Size> {
+        self.to_point().to_array()
+    }
+
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
+        let cp = CurvePoint::from_array(&arr)?;
+        let backend_pk = BackendPublicKey::<CurveType>::from_affine(cp.to_affine()).ok()?;
+        Some(Self(backend_pk))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use sha2::Sha256;
+    use signature::digest::Digest;
+
+    use super::{PublicKey, SecretKey};
+    use crate::SerializableToArray;
+
+    #[test]
+    fn test_serialize_secret_key() {
+        let sk = SecretKey::random();
+        let sk_arr = sk.to_array();
+        let sk_back = SecretKey::from_array(&sk_arr).unwrap();
+        assert_eq!(sk.to_secret_scalar(), sk_back.to_secret_scalar());
+    }
+
+    #[test]
+    fn test_serialize_public_key() {
+        let sk = SecretKey::random();
+        let pk = PublicKey::from_secret_key(&sk);
+        let pk_arr = pk.to_array();
+        let pk_back = PublicKey::from_array(&pk_arr).unwrap();
+        assert_eq!(pk, pk_back);
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        let sk = SecretKey::random();
+        let message = b"asdafdahsfdasdfasd";
+        let digest = Sha256::new().chain(message);
+        let signature = sk.sign_digest(digest);
+
+        let pk = PublicKey::from_secret_key(&sk);
+        let digest = Sha256::new().chain(message);
+        assert!(pk.verify_digest(digest, &signature));
+    }
+}

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -31,9 +31,8 @@
 //! // Invocation of `encrypt()` returns both the ciphertext and a capsule.
 //! // Note that anyone with Alice's public key can perform this operation.
 //!
-//! let params = Parameters::new();
 //! let plaintext = b"peace at dawn";
-//! let (capsule, ciphertext) = encrypt(&params, &alice_pk, plaintext).unwrap();
+//! let (capsule, ciphertext) = encrypt(&alice_pk, plaintext).unwrap();
 //!
 //! // Since data was encrypted with Alice's public key, Alice can open the capsule
 //! // and decrypt the ciphertext with her private key.
@@ -47,7 +46,7 @@
 //!
 //! let n = 3; // how many fragments to create
 //! let m = 2; // how many should be enough to decrypt
-//! let kfrags = generate_kfrags(&params, &alice_sk, &bob_pk, &signing_sk, m, n, true, true);
+//! let kfrags = generate_kfrags(&alice_sk, &bob_pk, &signing_sk, m, n, true, true);
 //!
 //! // Bob asks several Ursulas to re-encrypt the capsule so he can open it.
 //! // Each Ursula performs re-encryption on the capsule using the kfrag provided by Alice,
@@ -112,5 +111,4 @@ pub use capsule::Capsule;
 pub use capsule_frag::CapsuleFrag;
 pub use curve::{PublicKey, SecretKey};
 pub use key_frag::KeyFrag;
-pub use params::Parameters;
 pub use traits::SerializableToArray;

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -102,6 +102,7 @@ mod dem;
 mod hashing;
 mod hashing_ds;
 mod key_frag;
+mod keys;
 mod params;
 mod pre;
 mod traits;
@@ -111,6 +112,6 @@ pub use pre::{decrypt_original, decrypt_reencrypted, encrypt, reencrypt};
 
 pub use capsule::Capsule;
 pub use capsule_frag::CapsuleFrag;
-pub use curve::{PublicKey, SecretKey};
 pub use key_frag::KeyFrag;
+pub use keys::{PublicKey, SecretKey};
 pub use traits::SerializableToArray;

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -91,9 +91,6 @@
 
 extern crate alloc;
 
-#[macro_use]
-extern crate typenum;
-
 pub mod bench; // Re-export some internals for benchmarks.
 mod capsule;
 mod capsule_frag;

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -60,11 +60,13 @@
 //!
 //! // Ursula 0
 //! assert!(kfrags[0].verify(&signing_pk, Some(&alice_pk), Some(&bob_pk)));
-//! let cfrag0 = reencrypt(&capsule, &kfrags[0], None);
+//! let metadata0 = b"metadata0";
+//! let cfrag0 = reencrypt(&capsule, &kfrags[0], Some(metadata0));
 //!
 //! // Ursula 1
 //! assert!(kfrags[1].verify(&signing_pk, Some(&alice_pk), Some(&bob_pk)));
-//! let cfrag1 = reencrypt(&capsule, &kfrags[1], None);
+//! let metadata1 = b"metadata1";
+//! let cfrag1 = reencrypt(&capsule, &kfrags[1], Some(metadata1));
 //!
 //! // ...
 //!
@@ -72,8 +74,8 @@
 //! // and then decrypts the re-encrypted ciphertext.
 //!
 //! // Bob can optionally check that cfrags are valid
-//! assert!(cfrag0.verify(&capsule, &alice_pk, &bob_pk, &signing_pk));
-//! assert!(cfrag1.verify(&capsule, &alice_pk, &bob_pk, &signing_pk));
+//! assert!(cfrag0.verify(&capsule, &alice_pk, &bob_pk, &signing_pk, Some(metadata0)));
+//! assert!(cfrag1.verify(&capsule, &alice_pk, &bob_pk, &signing_pk, Some(metadata1)));
 //!
 //! let plaintext_bob = decrypt_reencrypted(
 //!     &bob_sk, &alice_pk, &capsule, &[cfrag0, cfrag1], &ciphertext).unwrap();

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -113,5 +113,5 @@ pub use pre::{decrypt_original, decrypt_reencrypted, encrypt, reencrypt};
 pub use capsule::Capsule;
 pub use capsule_frag::CapsuleFrag;
 pub use key_frag::KeyFrag;
-pub use keys::{PublicKey, SecretKey};
+pub use keys::{PublicKey, SecretKey, SecretKeyFactory};
 pub use traits::SerializableToArray;

--- a/umbral-pre/src/params.rs
+++ b/umbral-pre/src/params.rs
@@ -13,15 +13,19 @@ pub struct Parameters {
 impl Parameters {
     /// Creates a new parameter object.
     pub fn new() -> Self {
-        // Some future-proofing for a scenario where someone uses a different generator.
-        // We wouldn't want `u` to be the same in that case.
-        let g = CurvePoint::generator();
-        let g_bytes = g.to_array();
+        // The goal is to find two distinct points `g` and `u` for which `log_g(u)` is unknown.
+        // `g` is fixed to be the generator because it has to be the same
+        // as the one used for secret/public keys, and it is standardized (for a given curve).
 
         // Only fails with a minuscule probability,
-        // or if the size of a point is too large for the hasher.
-        // In any case, we will notice it in tests.
-        let u = unsafe_hash_to_point(b"POINT_U", &g_bytes).unwrap();
+        // and since `g` is fixed here, we can just ignore the panic branch,
+        // because we know it succeeds.
+
+        // Technically, we don't need the DST here now since it's a custom hashing function
+        // used for exactly one purpose (and, really, on only one value).
+        // But in view of possible replacement with the standard hash-to-curve (see #35),
+        // which will need a DST, we're using a DST here as well.
+        let u = unsafe_hash_to_point(b"PARAMETERS", b"POINT_U").unwrap();
 
         Self { u }
     }

--- a/umbral-pre/src/params.rs
+++ b/umbral-pre/src/params.rs
@@ -1,8 +1,5 @@
 use crate::curve::CurvePoint;
 use crate::hashing::unsafe_hash_to_point;
-use crate::traits::SerializableToArray;
-
-use generic_array::GenericArray;
 
 /// An object containing shared scheme parameters.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -31,43 +28,15 @@ impl Parameters {
     }
 }
 
-impl SerializableToArray for Parameters {
-    type Size = <CurvePoint as SerializableToArray>::Size;
-
-    fn to_array(&self) -> GenericArray<u8, Self::Size> {
-        self.u.to_array()
-    }
-
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Option<Self> {
-        let u = CurvePoint::take_last(*arr)?;
-        Some(Self { u })
-    }
-}
-
-impl Default for Parameters {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
     use super::Parameters;
-    use crate::SerializableToArray;
-
-    #[test]
-    fn test_serialize() {
-        let p = Parameters::new();
-        let p_arr = p.to_array();
-        let p_back = Parameters::from_array(&p_arr).unwrap();
-        assert_eq!(p, p_back);
-    }
 
     #[test]
     fn test_default() {
         let p1 = Parameters::new();
-        let p2 = Parameters::default();
+        let p2 = Parameters::new();
         assert_eq!(p1, p2);
     }
 }

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -19,7 +19,8 @@ pub fn encrypt(
     plaintext: &[u8],
 ) -> Option<(Capsule, Box<[u8]>)> {
     let (capsule, key_seed) = Capsule::from_pubkey(params, pk);
-    let dem = DEM::new(&key_seed.to_array());
+    // TODO (#43): add salt and info here?
+    let dem = DEM::new(&key_seed.to_array(), None, None);
     let capsule_bytes = capsule.to_array();
     let ciphertext = dem.encrypt(plaintext, &capsule_bytes)?;
     Some((capsule, ciphertext))
@@ -33,7 +34,8 @@ pub fn decrypt_original(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_original(decrypting_sk);
-    let dem = DEM::new(&key_seed.to_array());
+    // TODO (#43): add salt and info here?
+    let dem = DEM::new(&key_seed.to_array(), None, None);
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
@@ -65,7 +67,8 @@ pub fn decrypt_reencrypted(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_reencrypted(decrypting_sk, delegating_pk, cfrags)?;
-    let dem = DEM::new(&key_seed.to_array());
+    // TODO (#43): add salt and info here?
+    let dem = DEM::new(&key_seed.to_array(), None, None);
     dem.decrypt(&ciphertext, &capsule.to_array())
 }
 

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -14,8 +14,7 @@ use alloc::boxed::Box;
 /// Returns the KEM [`Capsule`] and the ciphertext.
 pub fn encrypt(pk: &PublicKey, plaintext: &[u8]) -> Option<(Capsule, Box<[u8]>)> {
     let (capsule, key_seed) = Capsule::from_public_key(pk);
-    // TODO (#43): add salt and info here?
-    let dem = DEM::new(&key_seed.to_array(), None, None);
+    let dem = DEM::new(&key_seed.to_array());
     let capsule_bytes = capsule.to_array();
     let ciphertext = dem.encrypt(plaintext, &capsule_bytes)?;
     Some((capsule, ciphertext))
@@ -29,8 +28,7 @@ pub fn decrypt_original(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_original(decrypting_sk);
-    // TODO (#43): add salt and info here?
-    let dem = DEM::new(&key_seed.to_array(), None, None);
+    let dem = DEM::new(&key_seed.to_array());
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
@@ -62,8 +60,7 @@ pub fn decrypt_reencrypted(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_reencrypted(decrypting_sk, delegating_pk, cfrags)?;
-    // TODO (#43): add salt and info here?
-    let dem = DEM::new(&key_seed.to_array(), None, None);
+    let dem = DEM::new(&key_seed.to_array());
     dem.decrypt(&ciphertext, &capsule.to_array())
 }
 

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -131,9 +131,10 @@ mod tests {
         )));
 
         // Bob requests re-encryption to some set of `threshold` ursulas
+        let metadata = b"metadata";
         let cfrags: Vec<CapsuleFrag> = kfrags[0..threshold]
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag, None))
+            .map(|kfrag| reencrypt(&capsule, &kfrag, Some(metadata)))
             .collect();
 
         // Bob checks that the received cfrags are valid
@@ -142,6 +143,7 @@ mod tests {
             &delegating_pk,
             &receiving_pk,
             &signing_pk,
+            Some(metadata),
         )));
 
         // Decryption by Bob

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -13,7 +13,7 @@ use alloc::boxed::Box;
 /// and encapsulates the key for later reencryption.
 /// Returns the KEM [`Capsule`] and the ciphertext.
 pub fn encrypt(pk: &PublicKey, plaintext: &[u8]) -> Option<(Capsule, Box<[u8]>)> {
-    let (capsule, key_seed) = Capsule::from_pubkey(pk);
+    let (capsule, key_seed) = Capsule::from_public_key(pk);
     // TODO (#43): add salt and info here?
     let dem = DEM::new(&key_seed.to_array(), None, None);
     let capsule_bytes = capsule.to_array();

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -3,7 +3,7 @@
 use crate::capsule::Capsule;
 use crate::capsule_frag::CapsuleFrag;
 use crate::curve::{PublicKey, SecretKey};
-use crate::dem::UmbralDEM;
+use crate::dem::DEM;
 use crate::key_frag::KeyFrag;
 use crate::params::Parameters;
 use crate::traits::SerializableToArray;
@@ -19,7 +19,7 @@ pub fn encrypt(
     plaintext: &[u8],
 ) -> Option<(Capsule, Box<[u8]>)> {
     let (capsule, key_seed) = Capsule::from_pubkey(params, pk);
-    let dem = UmbralDEM::new(&key_seed.to_array());
+    let dem = DEM::new(&key_seed.to_array());
     let capsule_bytes = capsule.to_array();
     let ciphertext = dem.encrypt(plaintext, &capsule_bytes)?;
     Some((capsule, ciphertext))
@@ -33,7 +33,7 @@ pub fn decrypt_original(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_original(decrypting_sk);
-    let dem = UmbralDEM::new(&key_seed.to_array());
+    let dem = DEM::new(&key_seed.to_array());
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
@@ -65,7 +65,7 @@ pub fn decrypt_reencrypted(
     ciphertext: impl AsRef<[u8]>,
 ) -> Option<Box<[u8]>> {
     let key_seed = capsule.open_reencrypted(decrypting_sk, delegating_pk, cfrags)?;
-    let dem = UmbralDEM::new(&key_seed.to_array());
+    let dem = DEM::new(&key_seed.to_array());
     dem.decrypt(&ciphertext, &capsule.to_array())
 }
 

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -2,9 +2,9 @@
 
 use crate::capsule::Capsule;
 use crate::capsule_frag::CapsuleFrag;
-use crate::curve::{PublicKey, SecretKey};
 use crate::dem::DEM;
 use crate::key_frag::KeyFrag;
+use crate::keys::{PublicKey, SecretKey};
 use crate::traits::SerializableToArray;
 
 use alloc::boxed::Box;


### PR DESCRIPTION
Necessary adjustments to reach binary compatibility with PyUmbral. See the related https://github.com/nucypher/pyUmbral/pull/263

- stopped bundling `Parameters` with objects and decoupled `u` from `g` (as decided in #3)
- renamed `UmbralDEM` to `DEM` (we have namespaces for that)
- replaced ChaCha with XChaCha for DEM
- used domain separation tags for all instances of hashing 
- exposed serialization via `__bytes__()` and `from_bytes()` in Python bindings (part of #11)
- added `SecretKeyFactory` for secret key derivation
- changed order of parameters in `CapsuleFrag.verify()` to match the rest of the library (and the Python version)
- various internal naming changes

Effectively fixes #27, although nothing really changed in the binary format on the Rust side (except for domain tags, missing `Parameters` and XChaCha); most of the work is done on the Python side

Note for reviewers:
- It may be more convenient to review commit by commit

Notes:
- In `PyUmbral` `UmbralSecretKey` is (de)serialized using `nacl`'s `SecretBox` with the password expanded in `nucypher`. This behavior can be replicated by using `xsalsa20poly1305` crate if necessary. But since we are breaking capsule compatibility anyway, users probably won't want to hold on to their `UmbralPrivateKey`s, so we can use the preferred `chacha20poly1305` + password expansion with `SHA256` (our hash of choice), which is already exposed via `UmbralDEM` (renamed to `DEM` in this PR)
