### PR TITLE
Final touches for the API

### DIFF
--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -26,6 +26,10 @@ API reference
 
         Generates a new secret key.
 
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
+
 .. py:class:: SecretKeyFactory
 
     A deterministic generator of :py:class:`SecretKey` objects.
@@ -46,6 +50,10 @@ API reference
 
         Restores the object from a bytestring.
 
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
+
 .. py:class:: PublicKey
 
     An ``umbral-pre`` public key object.
@@ -61,6 +69,10 @@ API reference
     .. py:staticmethod:: from_bytes(data: bytes) -> PublicKey
 
         Restores the object from a bytestring.
+
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
 
     .. py:method:: __hash__() -> int
 
@@ -88,6 +100,10 @@ API reference
         Returns ``True`` if the ``message`` was signed by someone possessing the secret counterpart
         to ``verifying_key``.
 
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
+
 .. py:class:: Capsule
 
     An encapsulated symmetric key.
@@ -99,6 +115,10 @@ API reference
     .. py:staticmethod:: from_bytes(data: bytes) -> Capsule
 
         Restores the object from a bytestring.
+
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
 
     .. py:method:: __hash__() -> int
 
@@ -142,6 +162,10 @@ API reference
 
         Restores the object from a bytestring.
 
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
+
     .. py:method:: __hash__() -> int
 
         Returns a hash of self.
@@ -157,6 +181,10 @@ API reference
 
         Intended for internal storage;
         make sure that the bytes come from a trusted source.
+
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
 
 .. py:class:: CapsuleFrag
 
@@ -174,6 +202,10 @@ API reference
 
         Restores the object from a bytestring.
 
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
+
     .. py:method:: __hash__() -> int
 
         Returns a hash of self.
@@ -181,6 +213,10 @@ API reference
 .. py:class:: VerifiedCapsuleFrag
 
     A verified capsule fragment, good for decryption.
+
+    .. py:staticmethod:: serialized_size() -> int
+
+        Returns the size in bytes of the serialized representation of this object.
 
 
 Indices and tables

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -151,6 +151,14 @@ API reference
 
     A verified key fragment, good for reencryption.
 
+    .. py:method:: from_verified_bytes(data: bytes) -> VerifiedKeyFrag
+
+        Restores a verified keyfrag directly from serialized bytes,
+        skipping :py:meth:`KeyFrag.verify` call.
+
+        Intended for internal storage;
+        make sure that the bytes come from a trusted source.
+
 .. py:class:: CapsuleFrag
 
     A reencrypted fragment of an encapsulated symmetric key.

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -104,13 +104,13 @@ API reference
 
         Returns a hash of self.
 
-.. py:function:: encrypt(pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]
+.. py:function:: encrypt(delegating_pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]
 
-    Creates a symmetric key, encrypts ``plaintext`` with it, and returns the encapsulated symmetric key along with the ciphertext. ``pk`` is the public key of the recipient.
+    Creates a symmetric key, encrypts ``plaintext`` with it, and returns the encapsulated symmetric key along with the ciphertext. ``delegating_pk`` is the public key of the delegator.
 
-.. py:function:: decrypt_original(sk: SecretKey, capsule: Capsule, ciphertext: bytes) -> bytes
+.. py:function:: decrypt_original(delegating_sk: SecretKey, capsule: Capsule, ciphertext: bytes) -> bytes
 
-    Decrypts ``ciphertext`` with the key used to encrypt it.
+    Decrypts ``ciphertext`` with the secret key of the delegator.
 
 .. py:function:: generate_kfrags(delegating_sk: SecretKey, receiving_pk: PublicKey, signer: Signer, threshold: int, num_kfrags: int, sign_delegating_key: bool, sign_receiving_key: bool) -> List[VerifiedKeyFrag]
 
@@ -122,7 +122,7 @@ API reference
 
     Reencrypts a capsule using a key fragment.
 
-.. py:function:: decrypt_reencrypted(decrypting_sk: SecretKey, delegating_pk: PublicKey, capsule: Capsule, cfrags: Sequence[VerifiedCapsuleFrag], ciphertext: bytes) -> Optional[bytes]
+.. py:function:: decrypt_reencrypted(receiving_sk: SecretKey, delegating_pk: PublicKey, capsule: Capsule, cfrags: Sequence[VerifiedCapsuleFrag], ciphertext: bytes) -> Optional[bytes]
 
     Attempts to decrypt the plaintext using the original capsule and reencrypted capsule fragments (at least ``threshold`` of them, see :py:func:`generate_kfrags`).
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -118,10 +118,9 @@ API reference
 
     If ``sign_delegating_key`` or ``sign_receiving_key`` are ``True``, include these keys in the signature allowing proxies to verify the fragments were created with a given key or for a given key, respectively.
 
-.. py:function:: reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag, metadata: Optional[bytes]) -> VerifiedCapsuleFrag
+.. py:function:: reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag
 
     Reencrypts a capsule using a key fragment.
-    May include optional ``metadata`` to sign.
 
 .. py:function:: decrypt_reencrypted(decrypting_sk: SecretKey, delegating_pk: PublicKey, capsule: Capsule, cfrags: Sequence[VerifiedCapsuleFrag], ciphertext: bytes) -> Optional[bytes]
 
@@ -163,7 +162,7 @@ API reference
 
     A reencrypted fragment of an encapsulated symmetric key.
 
-    .. py:method:: verify(capsule: Capsule, verifying_pk: PublicKey, delegating_pk: PublicKey, receiving_pk: PublicKey, metadata: Optional[bytes]) -> VerifiedCapsuleFrag
+    .. py:method:: verify(capsule: Capsule, verifying_pk: PublicKey, delegating_pk: PublicKey, receiving_pk: PublicKey) -> VerifiedCapsuleFrag
 
         Verifies the integrity of the fragment.
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -26,6 +26,14 @@ API reference
 
         Generates a new secret key.
 
+    .. py:method:: __bytes__() -> bytes
+
+        Serializes the object into a bytestring.
+
+    .. py:staticmethod:: from_bytes(data: bytes) -> SecretKey
+
+        Restores the object from a bytestring.
+
     .. py:staticmethod:: serialized_size() -> int
 
         Returns the size in bytes of the serialized representation of this object.
@@ -38,7 +46,7 @@ API reference
 
         Generates a new random factory.
 
-    .. py:method:: secret_key_by_label(label: bytes) -> SecretKey
+    .. py:method:: secret_key_by_label(label: bytes) -> SecretKeyFactory
 
         Generates a new :py:class:`SecretKey` using ``label`` as a seed.
 
@@ -100,6 +108,14 @@ API reference
         Returns ``True`` if the ``message`` was signed by someone possessing the secret counterpart
         to ``verifying_key``.
 
+    .. py:method:: __bytes__() -> bytes
+
+        Serializes the object into a bytestring.
+
+    .. py:staticmethod:: from_bytes(data: bytes) -> Signature
+
+        Restores the object from a bytestring.
+
     .. py:staticmethod:: serialized_size() -> int
 
         Returns the size in bytes of the serialized representation of this object.
@@ -107,6 +123,14 @@ API reference
 .. py:class:: Capsule
 
     An encapsulated symmetric key.
+
+    .. py:method:: __bytes__() -> bytes
+
+        Serializes the object into a bytestring.
+
+    .. py:staticmethod:: from_bytes(data: bytes) -> Capsule
+
+        Restores the object from a bytestring.
 
     .. py:method:: __bytes__() -> bytes
 
@@ -182,6 +206,10 @@ API reference
         Intended for internal storage;
         make sure that the bytes come from a trusted source.
 
+    .. py:method:: __bytes__() -> bytes
+
+        Serializes the object into a bytestring.
+
     .. py:staticmethod:: serialized_size() -> int
 
         Returns the size in bytes of the serialized representation of this object.
@@ -213,6 +241,10 @@ API reference
 .. py:class:: VerifiedCapsuleFrag
 
     A verified capsule fragment, good for decryption.
+
+    .. py:method:: __bytes__() -> bytes
+
+        Serializes the object into a bytestring.
 
     .. py:staticmethod:: serialized_size() -> int
 

--- a/umbral-pre-python/example/example.py
+++ b/umbral-pre-python/example/example.py
@@ -65,14 +65,12 @@ kfrag1 = KeyFrag.from_bytes(bytes(verified_kfrags[1]))
 # are valid and perform the reencryption.
 
 # Ursula 0
-metadata0 = b"metadata0"
 verified_kfrag0 = kfrag0.verify(verifying_pk, alice_pk, bob_pk)
-verified_cfrag0 = umbral_pre.reencrypt(capsule, kfrags[0], metadata0)
+verified_cfrag0 = umbral_pre.reencrypt(capsule, kfrags[0])
 
 # Ursula 1
-metadata1 = b"metadata1"
 verified_kfrag1 = kfrag1.verify(verifying_pk, alice_pk, bob_pk)
-verified_cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1], metadata1)
+verified_cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1])
 
 # ...
 
@@ -84,8 +82,8 @@ cfrag1 = CapsuleFrag.from_bytes(bytes(verified_cfrag1))
 # and then decrypts the re-encrypted ciphertext.
 
 # Bob must check that cfrags are valid
-verified_cfrag0 = cfrag0.verify(capsule, verifying_pk, alice_pk, bob_pk, metadata0)
-verified_cfrag1 = cfrag1.verify(capsule, verifying_pk, alice_pk, bob_pk, metadata1)
+verified_cfrag0 = cfrag0.verify(capsule, verifying_pk, alice_pk, bob_pk)
+verified_cfrag1 = cfrag1.verify(capsule, verifying_pk, alice_pk, bob_pk)
 
 # Decryption by Bob
 plaintext_bob = umbral_pre.decrypt_reencrypted(

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -10,7 +10,7 @@ use pyo3::PyObjectProtocol;
 use umbral_pre::{
     CapsuleFragVerificationError, DecryptionError, DeserializableFromArray, DeserializationError,
     EncryptionError, KeyFragVerificationError, OpenReencryptedError, ReencryptionError,
-    SecretKeyFactoryError, SerializableToArray,
+    RepresentableAsArray, SecretKeyFactoryError, SerializableToArray,
 };
 
 // Helper traits to generalize implementing various Python protocol functions for our types.
@@ -132,6 +132,11 @@ impl SecretKey {
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
     }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::SecretKey::serialized_size()
+    }
 }
 
 #[pyproto]
@@ -200,6 +205,11 @@ impl SecretKeyFactory {
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
     }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::SecretKeyFactory::serialized_size()
+    }
 }
 
 #[pyproto]
@@ -253,6 +263,11 @@ impl PublicKey {
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
+    }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::PublicKey::serialized_size()
     }
 }
 
@@ -354,6 +369,11 @@ impl Signature {
     pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
         self.backend.verify(&verifying_key.backend, message)
     }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::Signature::serialized_size()
+    }
 }
 
 #[pyproto]
@@ -404,6 +424,11 @@ impl Capsule {
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
+    }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::Capsule::serialized_size()
     }
 }
 
@@ -523,6 +548,11 @@ impl KeyFrag {
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
     }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::KeyFrag::serialized_size()
+    }
 }
 
 #[pyproto]
@@ -569,6 +599,11 @@ impl VerifiedKeyFrag {
         umbral_pre::VerifiedKeyFrag::from_verified_bytes(data)
             .map(|vkfrag| Self { backend: vkfrag })
             .map_err(map_serialization_err::<VerifiedKeyFrag>)
+    }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::VerifiedKeyFrag::serialized_size()
     }
 }
 
@@ -676,6 +711,11 @@ impl CapsuleFrag {
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
     }
+
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::CapsuleFrag::serialized_size()
+    }
 }
 
 #[pyproto]
@@ -731,6 +771,14 @@ impl PyObjectProtocol for VerifiedCapsuleFrag {
 
     fn __str__(&self) -> PyResult<String> {
         hexstr(self)
+    }
+}
+
+#[pymethods]
+impl VerifiedCapsuleFrag {
+    #[staticmethod]
+    pub fn serialized_size() -> usize {
+        umbral_pre::VerifiedCapsuleFrag::serialized_size()
     }
 }
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -49,9 +49,9 @@ fn map_serialization_err<T: HasName>(err: DeserializationError) -> PyErr {
 }
 
 fn from_bytes<T: FromSerializableBackend<U> + HasName, U: DeserializableFromArray>(
-    bytes: &[u8],
+    data: &[u8],
 ) -> PyResult<T> {
-    U::from_bytes(bytes)
+    U::from_bytes(data)
         .map(T::from_backend)
         .map_err(map_serialization_err::<T>)
 }
@@ -129,8 +129,8 @@ impl SecretKey {
     }
 
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 
@@ -197,8 +197,8 @@ impl SecretKeyFactory {
     }
 
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 
@@ -251,8 +251,8 @@ impl PublicKey {
     }
 
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 
@@ -347,8 +347,8 @@ impl HasName for Signature {
 #[pymethods]
 impl Signature {
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 
     pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
@@ -402,8 +402,8 @@ impl HasName for Capsule {
 #[pymethods]
 impl Capsule {
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 
@@ -520,8 +520,8 @@ impl KeyFrag {
     }
 
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 
@@ -565,8 +565,8 @@ impl HasName for VerifiedKeyFrag {
 #[pymethods]
 impl VerifiedKeyFrag {
     #[staticmethod]
-    pub fn from_verified_bytes(bytes: &[u8]) -> PyResult<Self> {
-        umbral_pre::VerifiedKeyFrag::from_verified_bytes(bytes)
+    pub fn from_verified_bytes(data: &[u8]) -> PyResult<Self> {
+        umbral_pre::VerifiedKeyFrag::from_verified_bytes(data)
             .map(|vkfrag| Self { backend: vkfrag })
             .map_err(map_serialization_err::<VerifiedKeyFrag>)
     }
@@ -673,8 +673,8 @@ impl CapsuleFrag {
     }
 
     #[staticmethod]
-    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
-        from_bytes(bytes)
+    pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        from_bytes(data)
     }
 }
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -647,7 +647,6 @@ impl CapsuleFrag {
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
-        metadata: Option<&[u8]>,
     ) -> PyResult<VerifiedCapsuleFrag> {
         self.backend
             .verify(
@@ -655,7 +654,6 @@ impl CapsuleFrag {
                 &verifying_pk.backend,
                 &delegating_pk.backend,
                 &receiving_pk.backend,
-                metadata,
             )
             .map_err(|err| match err {
                 CapsuleFragVerificationError::IncorrectKeyFragSignature => {
@@ -733,12 +731,8 @@ impl PyObjectProtocol for VerifiedCapsuleFrag {
 }
 
 #[pyfunction]
-pub fn reencrypt(
-    capsule: &Capsule,
-    kfrag: &VerifiedKeyFrag,
-    metadata: Option<&[u8]>,
-) -> VerifiedCapsuleFrag {
-    let backend_vcfrag = umbral_pre::reencrypt(&capsule.backend, &kfrag.backend, metadata);
+pub fn reencrypt(capsule: &Capsule, kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
+    let backend_vcfrag = umbral_pre::reencrypt(&capsule.backend, &kfrag.backend);
     VerifiedCapsuleFrag {
         backend: backend_vcfrag,
     }

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -63,7 +63,8 @@ class KeyFrag:
 
 
 class VerifiedKeyFrag:
-    ...
+    def from_verified_bytes(data: bytes) -> VerifiedKeyFrag:
+        ...
 
 
 def generate_kfrags(

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -2,8 +2,13 @@ from typing import Optional, Tuple, List, Sequence
 
 
 class SecretKey:
+
     @staticmethod
     def random() -> SecretKey:
+        ...
+
+    @staticmethod
+    def serialized_size() -> int:
         ...
 
 
@@ -16,10 +21,19 @@ class SecretKeyFactory:
     def secret_key_by_label(self, label: bytes) -> SecretKey:
         ...
 
+    @staticmethod
+    def serialized_size() -> int:
+        ...
+
 
 class PublicKey:
+
     @staticmethod
     def from_secret_key(sk: SecretKey) -> PublicKey:
+        ...
+
+    @staticmethod
+    def serialized_size() -> int:
         ...
 
 
@@ -40,8 +54,16 @@ class Signature:
     def verify(verifying_key: PublicKey, message: bytes) -> bool:
         ...
 
+    @staticmethod
+    def serialized_size() -> int:
+        ...
 
-class Capsule: ...
+
+class Capsule:
+
+    @staticmethod
+    def serialized_size() -> int:
+        ...
 
 
 def encrypt(delegating_pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
@@ -53,6 +75,7 @@ def decrypt_original(delegating_sk: SecretKey, capsule: Capsule, ciphertext: byt
 
 
 class KeyFrag:
+
     def verify(
             self,
             verifying_pk: PublicKey,
@@ -61,9 +84,18 @@ class KeyFrag:
             ) -> VerifiedKeyFrag:
         ...
 
+    @staticmethod
+    def serialized_size() -> int:
+        ...
+
 
 class VerifiedKeyFrag:
+
     def from_verified_bytes(data: bytes) -> VerifiedKeyFrag:
+        ...
+
+    @staticmethod
+    def serialized_size() -> int:
         ...
 
 
@@ -80,6 +112,7 @@ def generate_kfrags(
 
 
 class CapsuleFrag:
+
     def verify(
             self,
             capsule: Capsule,
@@ -89,9 +122,16 @@ class CapsuleFrag:
             ) -> VerifiedCapsuleFrag:
         ...
 
+    @staticmethod
+    def serialized_size() -> int:
+        ...
+
 
 class VerifiedCapsuleFrag:
-    ...
+
+    @staticmethod
+    def serialized_size() -> int:
+        ...
 
 
 def reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag:

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -44,11 +44,11 @@ class Signature:
 class Capsule: ...
 
 
-def encrypt(pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
+def encrypt(delegating_pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
     ...
 
 
-def decrypt_original(sk: SecretKey, capsule: Capsule, ciphertext: bytes) -> bytes:
+def decrypt_original(delegating_sk: SecretKey, capsule: Capsule, ciphertext: bytes) -> bytes:
     ...
 
 
@@ -99,7 +99,7 @@ def reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag:
 
 
 def decrypt_reencrypted(
-        decrypting_sk: SecretKey,
+        receiving_sk: SecretKey,
         delegating_pk: PublicKey,
         capsule: Capsule,
         cfrags: Sequence[VerifiedCapsuleFrag],

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -86,7 +86,6 @@ class CapsuleFrag:
             verifying_pk: PublicKey,
             delegating_pk: PublicKey,
             receiving_pk: PublicKey,
-            metadata: Optional[bytes],
             ) -> VerifiedCapsuleFrag:
         ...
 
@@ -95,7 +94,7 @@ class VerifiedCapsuleFrag:
     ...
 
 
-def reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag, metadata: Optional[bytes]) -> VerifiedCapsuleFrag:
+def reencrypt(capsule: Capsule, kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag:
     ...
 
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -8,6 +8,10 @@ class SecretKey:
         ...
 
     @staticmethod
+    def from_bytes() -> SecretKey:
+        ...
+
+    @staticmethod
     def serialized_size() -> int:
         ...
 
@@ -22,6 +26,10 @@ class SecretKeyFactory:
         ...
 
     @staticmethod
+    def from_bytes() -> SecretKeyFactory:
+        ...
+
+    @staticmethod
     def serialized_size() -> int:
         ...
 
@@ -30,6 +38,10 @@ class PublicKey:
 
     @staticmethod
     def from_secret_key(sk: SecretKey) -> PublicKey:
+        ...
+
+    @staticmethod
+    def from_bytes() -> PublicKey:
         ...
 
     @staticmethod
@@ -52,6 +64,10 @@ class Signer:
 class Signature:
 
     def verify(verifying_key: PublicKey, message: bytes) -> bool:
+        ...
+
+    @staticmethod
+    def from_bytes() -> Signature:
         ...
 
     @staticmethod
@@ -82,6 +98,10 @@ class KeyFrag:
             delegating_pk: Optional[PublicKey],
             receiving_pk: Optional[PublicKey],
             ) -> VerifiedKeyFrag:
+        ...
+
+    @staticmethod
+    def from_bytes() -> KeyFrag:
         ...
 
     @staticmethod
@@ -120,6 +140,10 @@ class CapsuleFrag:
             delegating_pk: PublicKey,
             receiving_pk: PublicKey,
             ) -> VerifiedCapsuleFrag:
+        ...
+
+    @staticmethod
+    def from_bytes() -> CapsuleFrag:
         ...
 
     @staticmethod

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -66,12 +66,10 @@ let kfrags = umbral.generate_kfrags(
 // Bob must gather at least `m` cfrags in order to open the capsule.
 
 // Ursula 0
-let metadata0 = enc.encode("metadata0")
-let cfrag0 = umbral.reencrypt(capsule, kfrags[0], metadata0);
+let cfrag0 = umbral.reencrypt(capsule, kfrags[0]);
 
 // Ursula 1
-let metadata1 = enc.encode("metadata1");
-let cfrag1 = umbral.reencrypt(capsule, kfrags[1], metadata1);
+let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 

--- a/umbral-pre-wasm/example/index.js
+++ b/umbral-pre-wasm/example/index.js
@@ -61,12 +61,10 @@ let kfrags = umbral.generate_kfrags(
 // and perform the reencryption
 
 // Ursula 0
-let metadata0 = enc.encode("metadata0")
-let cfrag0 = umbral.reencrypt(capsule, kfrags[0], metadata0);
+let cfrag0 = umbral.reencrypt(capsule, kfrags[0]);
 
 // Ursula 1
-let metadata1 = enc.encode("metadata1");
-let cfrag1 = umbral.reencrypt(capsule, kfrags[1], metadata1);
+let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -134,14 +134,14 @@ impl CapsuleWithFrags {
     #[wasm_bindgen]
     pub fn decrypt_reencrypted(
         &self,
-        decrypting_sk: &SecretKey,
+        receiving_sk: &SecretKey,
         delegating_pk: &PublicKey,
         ciphertext: &[u8],
     ) -> Option<Box<[u8]>> {
         let backend_cfrags: Vec<umbral_pre::VerifiedCapsuleFrag> =
             self.cfrags.iter().cloned().map(|x| x.0).collect();
         umbral_pre::decrypt_reencrypted(
-            &decrypting_sk.0,
+            &receiving_sk.0,
             &delegating_pk.0,
             &self.capsule.0,
             backend_cfrags.as_slice(),
@@ -175,19 +175,19 @@ impl EncryptionResult {
 }
 
 #[wasm_bindgen]
-pub fn encrypt(pk: &PublicKey, plaintext: &[u8]) -> Option<EncryptionResult> {
-    let backend_pk = pk.0;
+pub fn encrypt(delegating_pk: &PublicKey, plaintext: &[u8]) -> Option<EncryptionResult> {
+    let backend_pk = delegating_pk.0;
     let (capsule, ciphertext) = umbral_pre::encrypt(&backend_pk, plaintext).unwrap();
     Some(EncryptionResult::new(ciphertext, Capsule(capsule)))
 }
 
 #[wasm_bindgen]
 pub fn decrypt_original(
-    decrypting_sk: &SecretKey,
+    delegating_sk: &SecretKey,
     capsule: &Capsule,
     ciphertext: &[u8],
 ) -> Box<[u8]> {
-    umbral_pre::decrypt_original(&decrypting_sk.0, &capsule.0, ciphertext).unwrap()
+    umbral_pre::decrypt_original(&delegating_sk.0, &capsule.0, ciphertext).unwrap()
 }
 
 #[wasm_bindgen]

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -95,10 +95,7 @@ impl CapsuleFrag {
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
-        metadata: Option<Box<[u8]>>,
     ) -> VerifiedCapsuleFrag {
-        // feels like there should be a better way...
-        let metadata_ref: Option<&[u8]> = metadata.as_ref().map(|s| s.as_ref());
         VerifiedCapsuleFrag(
             self.0
                 .verify(
@@ -106,7 +103,6 @@ impl CapsuleFrag {
                     &verifying_pk.0,
                     &delegating_pk.0,
                     &receiving_pk.0,
-                    metadata_ref,
                 )
                 .unwrap(),
         )
@@ -305,12 +301,7 @@ pub fn generate_kfrags(
 }
 
 #[wasm_bindgen]
-pub fn reencrypt(
-    capsule: &Capsule,
-    kfrag: &VerifiedKeyFrag,
-    metadata: Option<Box<[u8]>>,
-) -> VerifiedCapsuleFrag {
-    let metadata_slice = metadata.as_ref().map(|x| x.as_ref());
-    let backend_cfrag = umbral_pre::reencrypt(&capsule.0, &kfrag.0, metadata_slice);
+pub fn reencrypt(capsule: &Capsule, kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
+    let backend_cfrag = umbral_pre::reencrypt(&capsule.0, &kfrag.0);
     VerifiedCapsuleFrag(backend_cfrag)
 }

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -263,6 +263,15 @@ impl KeyFrag {
 #[wasm_bindgen]
 pub struct VerifiedKeyFrag(umbral_pre::VerifiedKeyFrag);
 
+#[wasm_bindgen]
+impl VerifiedKeyFrag {
+    pub fn from_verified_bytes(bytes: &[u8]) -> Self {
+        umbral_pre::VerifiedKeyFrag::from_verified_bytes(bytes)
+            .map(Self)
+            .unwrap()
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
 pub fn generate_kfrags(

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -239,7 +239,7 @@ mod tests {
 
         let vcfrags: Vec<_> = kfrags
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag, None))
+            .map(|kfrag| reencrypt(&capsule, &kfrag))
             .collect();
 
         let cfrags: Vec<_> = vcfrags.iter().cloned().map(|vcfrag| vcfrag.cfrag).collect();
@@ -260,7 +260,7 @@ mod tests {
 
         let vcfrags2: Vec<_> = kfrags2
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag, None))
+            .map(|kfrag| reencrypt(&capsule, &kfrag))
             .collect();
 
         let mismatched_cfrags: Vec<_> = vcfrags[0..1]

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -98,7 +98,7 @@ impl Capsule {
     }
 
     /// Generates a symmetric key and its associated KEM ciphertext
-    pub(crate) fn from_public_key(pk: &PublicKey) -> (Capsule, CurvePoint) {
+    pub(crate) fn from_public_key(delegating_pk: &PublicKey) -> (Capsule, CurvePoint) {
         let g = CurvePoint::generator();
 
         let priv_r = CurveScalar::random_nonzero();
@@ -111,7 +111,7 @@ impl Capsule {
 
         let s = &priv_u + &(&priv_r * &h);
 
-        let shared_key = &pk.to_point() * &(&priv_r + &priv_u);
+        let shared_key = &delegating_pk.to_point() * &(&priv_r + &priv_u);
 
         let capsule = Self::new(pub_r, pub_u, s);
 
@@ -119,8 +119,8 @@ impl Capsule {
     }
 
     /// Derive the same symmetric key
-    pub(crate) fn open_original(&self, private_key: &SecretKey) -> CurvePoint {
-        &(&self.point_e + &self.point_v) * &private_key.to_secret_scalar()
+    pub(crate) fn open_original(&self, delegating_sk: &SecretKey) -> CurvePoint {
+        &(&self.point_e + &self.point_v) * &delegating_sk.to_secret_scalar()
     }
 
     #[allow(clippy::many_single_char_names)]

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -44,18 +44,10 @@ pub(crate) fn hash_capsule_points(capsule_e: &CurvePoint, capsule_v: &CurvePoint
         .finalize()
 }
 
-pub(crate) fn hash_to_cfrag_verification(
-    points: &[CurvePoint],
-    metadata: Option<&[u8]>,
-) -> CurveScalar {
-    let digest = ScalarDigest::new_with_dst(b"CFRAG_VERIFICATION").chain_points(points);
-
-    let digest = match metadata {
-        Some(s) => digest.chain_bytes(s),
-        None => digest,
-    };
-
-    digest.finalize()
+pub(crate) fn hash_to_cfrag_verification(points: &[CurvePoint]) -> CurveScalar {
+    ScalarDigest::new_with_dst(b"CFRAG_VERIFICATION")
+        .chain_points(points)
+        .finalize()
 }
 
 pub(crate) fn kfrag_signature_message(

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -331,6 +331,15 @@ impl VerifiedKeyFrag {
             kfrag: KeyFrag::from_base(base, sign_delegating_key, sign_receiving_key),
         }
     }
+
+    /// Restores a verified keyfrag directly from serialized bytes,
+    /// skipping [`KeyFrag::verify`] call.
+    ///
+    /// Intended for internal storage;
+    /// make sure that the bytes come from a trusted source.
+    pub fn from_verified_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
+        KeyFrag::from_bytes(bytes).map(|kfrag| Self { kfrag })
+    }
 }
 
 pub(crate) struct KeyFragBase {

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -337,8 +337,8 @@ impl VerifiedKeyFrag {
     ///
     /// Intended for internal storage;
     /// make sure that the bytes come from a trusted source.
-    pub fn from_verified_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
-        KeyFrag::from_bytes(bytes).map(|kfrag| Self { kfrag })
+    pub fn from_verified_bytes(data: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
+        KeyFrag::from_bytes(data).map(|kfrag| Self { kfrag })
     }
 }
 

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -64,14 +64,12 @@
 //! // and perform the reencryption
 //!
 //! // Ursula 0
-//! let metadata0 = b"metadata0";
 //! let verified_kfrag0 = kfrag0.verify(&verifying_pk, Some(&alice_pk), Some(&bob_pk)).unwrap();
-//! let verified_cfrag0 = reencrypt(&capsule, &verified_kfrag0, Some(metadata0));
+//! let verified_cfrag0 = reencrypt(&capsule, &verified_kfrag0);
 //!
 //! // Ursula 1
-//! let metadata1 = b"metadata1";
 //! let verified_kfrag1 = kfrag1.verify(&verifying_pk, Some(&alice_pk), Some(&bob_pk)).unwrap();
-//! let verified_cfrag1 = reencrypt(&capsule, &verified_kfrag1, Some(metadata1));
+//! let verified_cfrag1 = reencrypt(&capsule, &verified_kfrag1);
 //!
 //! // ...
 //!
@@ -84,10 +82,10 @@
 //!
 //! // Bob must check that cfrags are valid
 //! let verified_cfrag0 = cfrag0
-//!     .verify(&capsule, &verifying_pk, &alice_pk, &bob_pk, Some(metadata0))
+//!     .verify(&capsule, &verifying_pk, &alice_pk, &bob_pk)
 //!     .unwrap();
 //! let verified_cfrag1 = cfrag1
-//!     .verify(&capsule, &verifying_pk, &alice_pk, &bob_pk, Some(metadata1))
+//!     .verify(&capsule, &verifying_pk, &alice_pk, &bob_pk)
 //!     .unwrap();
 //!
 //! let plaintext_bob = decrypt_reencrypted(

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -90,12 +90,8 @@ pub fn generate_kfrags(
 ///
 /// One can call [`KeyFrag::verify()`](`crate::KeyFrag::verify`)
 /// before reencryption to check its integrity.
-pub fn reencrypt(
-    capsule: &Capsule,
-    verified_kfrag: &VerifiedKeyFrag,
-    metadata: Option<&[u8]>,
-) -> VerifiedCapsuleFrag {
-    VerifiedCapsuleFrag::reencrypted(capsule, &verified_kfrag.kfrag, metadata)
+pub fn reencrypt(capsule: &Capsule, verified_kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
+    VerifiedCapsuleFrag::reencrypted(capsule, &verified_kfrag.kfrag)
 }
 
 /// Decrypts the ciphertext using previously reencrypted capsule fragments.
@@ -204,10 +200,9 @@ mod tests {
             })
             .collect();
 
-        let metadata = b"metadata";
         let verified_cfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags[0..threshold]
             .iter()
-            .map(|vkfrag| reencrypt(&capsule, &vkfrag, Some(metadata)))
+            .map(|vkfrag| reencrypt(&capsule, &vkfrag))
             .collect();
 
         // Simulate network transfer
@@ -221,13 +216,7 @@ mod tests {
             .iter()
             .map(|cfrag| {
                 cfrag
-                    .verify(
-                        &capsule,
-                        &verifying_pk,
-                        &delegating_pk,
-                        &receiving_pk,
-                        Some(metadata),
-                    )
+                    .verify(&capsule, &verifying_pk, &delegating_pk, &receiving_pk)
                     .unwrap()
             })
             .collect();

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -24,6 +24,11 @@ pub trait RepresentableAsArray: Sized {
     // It would be nice to have a dependent type
     // type Array = GenericArray<u8, Self::Size>;
     // but it's currently an unstable feature or Rust.
+
+    /// Resulting array length exposed as a runtime method.
+    fn serialized_size() -> usize {
+        Self::Size::to_usize()
+    }
 }
 
 /// A trait denoting that the object can be serialized to an array of bytes
@@ -43,7 +48,7 @@ pub trait DeserializableFromArray: RepresentableAsArray {
     /// checking that its length is correct.
     fn from_bytes(data: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
         let data_slice = data.as_ref();
-        match data_slice.len().cmp(&Self::Size::to_usize()) {
+        match data_slice.len().cmp(&Self::serialized_size()) {
             Ordering::Greater => Err(DeserializationError::TooManyBytes),
             Ordering::Less => Err(DeserializationError::NotEnoughBytes),
             Ordering::Equal => {

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -41,13 +41,13 @@ pub trait DeserializableFromArray: RepresentableAsArray {
 
     /// Attempts to produce the object back from a dynamically sized byte array,
     /// checking that its length is correct.
-    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
-        let bytes_slice = bytes.as_ref();
-        match bytes_slice.len().cmp(&Self::Size::to_usize()) {
+    fn from_bytes(data: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
+        let data_slice = data.as_ref();
+        match data_slice.len().cmp(&Self::Size::to_usize()) {
             Ordering::Greater => Err(DeserializationError::TooManyBytes),
             Ordering::Less => Err(DeserializationError::NotEnoughBytes),
             Ordering::Equal => {
-                Self::from_array(GenericArray::<u8, Self::Size>::from_slice(bytes_slice))
+                Self::from_array(GenericArray::<u8, Self::Size>::from_slice(data_slice))
             }
         }
     }


### PR DESCRIPTION
Synced with https://github.com/nucypher/pyUmbral/pull/270

- add `VerifiedKeyFrag::from_verified_bytes()` (for storage purposes)
- remove metadata support from `reencrypt()` (see https://github.com/nucypher/nucypher/issues/259)
- rename `pk` to `delegating_pk` in `encrypt()`
- rename `decrypting_sk` to `delegating_sk` in `decrypt_original()`
- rename `decrypting_sk` to `receiving_sk` in `decrypt_reencrypted()`
- use `data` instead of `bytes` as the parameter name in deserialization functions. This is needed to prevent a conflict with builtin `bytes` in Python bindings; one could use a different parameter name in the bindings, but the actual parameter name is taken from the Rust side, so if it is used explicitly (e.g. `KeyFrag.from_bytes(data=something)`), and on the Rust side it is still `bytes`, it'll lead to a `TypeError`. So it is easier to just name it `data` throughout.
- expose object sizes for use in `nucypher` as `serialization_size()` staticmethod