### PR TITLE
Trait implementations and error handling

### DIFF
--- a/umbral-pre-python/Cargo.toml
+++ b/umbral-pre-python/Cargo.toml
@@ -11,4 +11,3 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.13", features = ["extension-module"] }
 umbral-pre = { path = "../umbral-pre" }
 generic-array = "0.14"
-hex = "0.4"

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -9,35 +9,35 @@ use pyo3::PyObjectProtocol;
 
 use umbral_pre::{
     CapsuleFragVerificationError, DecryptionError, DeserializableFromArray, DeserializationError,
-    EncryptionError, KeyFragVerificationError, OpenReencryptedError, ReencryptionError,
-    RepresentableAsArray, SecretKeyFactoryError, SerializableToArray,
+    EncryptionError, HasTypeName, KeyFragVerificationError, OpenReencryptedError,
+    ReencryptionError, RepresentableAsArray, SecretKeyFactoryError, SerializableToArray,
 };
 
 // Helper traits to generalize implementing various Python protocol functions for our types.
 
-trait AsSerializableBackend<T> {
+trait AsBackend<T> {
     fn as_backend(&self) -> &T;
 }
 
-trait FromSerializableBackend<T> {
+trait FromBackend<T> {
     fn from_backend(backend: T) -> Self;
 }
 
-trait HasName {
-    fn name() -> &'static str;
-}
-
-fn to_bytes<T: AsSerializableBackend<U>, U: SerializableToArray>(obj: &T) -> PyResult<PyObject> {
+fn to_bytes<T, U>(obj: &T) -> PyResult<PyObject>
+where
+    T: AsBackend<U>,
+    U: SerializableToArray,
+{
     let serialized = obj.as_backend().to_array();
     Python::with_gil(|py| -> PyResult<PyObject> {
         Ok(PyBytes::new(py, serialized.as_slice()).into())
     })
 }
 
-fn map_serialization_err<T: HasName>(err: DeserializationError) -> PyErr {
+fn map_deserialization_err<T: HasTypeName>(err: DeserializationError) -> PyErr {
     match err {
         DeserializationError::ConstructionFailure => {
-            PyValueError::new_err(format!("Failed to deserialize a {} object", T::name()))
+            PyValueError::new_err(format!("Failed to deserialize a {} object", T::type_name()))
         }
         DeserializationError::TooManyBytes => {
             PyValueError::new_err("The given bytestring is too long")
@@ -48,45 +48,43 @@ fn map_serialization_err<T: HasName>(err: DeserializationError) -> PyErr {
     }
 }
 
-fn from_bytes<T: FromSerializableBackend<U> + HasName, U: DeserializableFromArray>(
-    data: &[u8],
-) -> PyResult<T> {
+fn from_bytes<T, U>(data: &[u8]) -> PyResult<T>
+where
+    T: FromBackend<U>,
+    U: DeserializableFromArray + HasTypeName,
+{
     U::from_bytes(data)
         .map(T::from_backend)
-        .map_err(map_serialization_err::<T>)
+        .map_err(map_deserialization_err::<U>)
 }
 
-fn hash<T: AsSerializableBackend<U> + HasName, U: SerializableToArray>(obj: &T) -> PyResult<isize> {
+fn hash<T, U>(obj: &T) -> PyResult<isize>
+where
+    T: AsBackend<U>,
+    U: SerializableToArray + HasTypeName,
+{
     let serialized = obj.as_backend().to_array();
 
     // call `hash((class_name, bytes(obj)))`
     Python::with_gil(|py| {
         let builtins = PyModule::import(py, "builtins")?;
-        let arg1 = PyUnicode::new(py, T::name());
+        let arg1 = PyUnicode::new(py, U::type_name());
         let arg2: PyObject = PyBytes::new(py, serialized.as_slice()).into();
         builtins.getattr("hash")?.call1(((arg1, arg2),))?.extract()
     })
 }
 
-#[allow(clippy::unnecessary_wraps)] // Don't want to wrap it in Ok() on every call
-fn hexstr<T: AsSerializableBackend<U> + HasName, U: SerializableToArray>(
-    obj: &T,
-) -> PyResult<String> {
-    let hex_str = hex::encode(obj.as_backend().to_array().as_slice());
-    Ok(format!("{}:{}", T::name(), &hex_str[0..16]))
-}
-
-fn richcmp<T: HasName + PyClass + PartialEq>(
-    obj: &T,
-    other: PyRef<T>,
-    op: CompareOp,
-) -> PyResult<bool> {
+fn richcmp<T, U>(obj: &T, other: PyRef<T>, op: CompareOp) -> PyResult<bool>
+where
+    T: PyClass + PartialEq + AsBackend<U>,
+    U: HasTypeName,
+{
     match op {
         CompareOp::Eq => Ok(obj == &*other),
         CompareOp::Ne => Ok(obj != &*other),
         _ => Err(PyTypeError::new_err(format!(
             "{} objects are not ordered",
-            T::name()
+            U::type_name()
         ))),
     }
 }
@@ -101,21 +99,15 @@ pub struct SecretKey {
     backend: umbral_pre::SecretKey,
 }
 
-impl AsSerializableBackend<umbral_pre::SecretKey> for SecretKey {
+impl AsBackend<umbral_pre::SecretKey> for SecretKey {
     fn as_backend(&self) -> &umbral_pre::SecretKey {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::SecretKey> for SecretKey {
+impl FromBackend<umbral_pre::SecretKey> for SecretKey {
     fn from_backend(backend: umbral_pre::SecretKey) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for SecretKey {
-    fn name() -> &'static str {
-        "SecretKey"
     }
 }
 
@@ -150,7 +142,7 @@ impl PyObjectProtocol for SecretKey {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        Ok(format!("{}:...", Self::name()))
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -160,21 +152,15 @@ pub struct SecretKeyFactory {
     backend: umbral_pre::SecretKeyFactory,
 }
 
-impl AsSerializableBackend<umbral_pre::SecretKeyFactory> for SecretKeyFactory {
+impl AsBackend<umbral_pre::SecretKeyFactory> for SecretKeyFactory {
     fn as_backend(&self) -> &umbral_pre::SecretKeyFactory {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::SecretKeyFactory> for SecretKeyFactory {
+impl FromBackend<umbral_pre::SecretKeyFactory> for SecretKeyFactory {
     fn from_backend(backend: umbral_pre::SecretKeyFactory) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for SecretKeyFactory {
-    fn name() -> &'static str {
-        "SecretKeyFactory"
     }
 }
 
@@ -223,7 +209,7 @@ impl PyObjectProtocol for SecretKeyFactory {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        Ok(format!("{}:...", Self::name()))
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -233,21 +219,15 @@ pub struct PublicKey {
     backend: umbral_pre::PublicKey,
 }
 
-impl AsSerializableBackend<umbral_pre::PublicKey> for PublicKey {
+impl AsBackend<umbral_pre::PublicKey> for PublicKey {
     fn as_backend(&self) -> &umbral_pre::PublicKey {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::PublicKey> for PublicKey {
+impl FromBackend<umbral_pre::PublicKey> for PublicKey {
     fn from_backend(backend: umbral_pre::PublicKey) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for PublicKey {
-    fn name() -> &'static str {
-        "PublicKey"
     }
 }
 
@@ -286,7 +266,7 @@ impl PyObjectProtocol for PublicKey {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -296,9 +276,9 @@ pub struct Signer {
     backend: umbral_pre::Signer,
 }
 
-impl HasName for Signer {
-    fn name() -> &'static str {
-        "Signer"
+impl AsBackend<umbral_pre::Signer> for Signer {
+    fn as_backend(&self) -> &umbral_pre::Signer {
+        &self.backend
     }
 }
 
@@ -331,7 +311,7 @@ impl PyObjectProtocol for Signer {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        Ok(format!("{}:...", Self::name()))
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -341,21 +321,15 @@ pub struct Signature {
     backend: umbral_pre::Signature,
 }
 
-impl AsSerializableBackend<umbral_pre::Signature> for Signature {
+impl AsBackend<umbral_pre::Signature> for Signature {
     fn as_backend(&self) -> &umbral_pre::Signature {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::Signature> for Signature {
+impl FromBackend<umbral_pre::Signature> for Signature {
     fn from_backend(backend: umbral_pre::Signature) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for Signature {
-    fn name() -> &'static str {
-        "Signature"
     }
 }
 
@@ -391,7 +365,7 @@ impl PyObjectProtocol for Signature {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -401,21 +375,15 @@ pub struct Capsule {
     backend: umbral_pre::Capsule,
 }
 
-impl AsSerializableBackend<umbral_pre::Capsule> for Capsule {
+impl AsBackend<umbral_pre::Capsule> for Capsule {
     fn as_backend(&self) -> &umbral_pre::Capsule {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::Capsule> for Capsule {
+impl FromBackend<umbral_pre::Capsule> for Capsule {
     fn from_backend(backend: umbral_pre::Capsule) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for Capsule {
-    fn name() -> &'static str {
-        "Capsule"
     }
 }
 
@@ -447,7 +415,7 @@ impl PyObjectProtocol for Capsule {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -504,21 +472,15 @@ pub struct KeyFrag {
     backend: umbral_pre::KeyFrag,
 }
 
-impl AsSerializableBackend<umbral_pre::KeyFrag> for KeyFrag {
+impl AsBackend<umbral_pre::KeyFrag> for KeyFrag {
     fn as_backend(&self) -> &umbral_pre::KeyFrag {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::KeyFrag> for KeyFrag {
+impl FromBackend<umbral_pre::KeyFrag> for KeyFrag {
     fn from_backend(backend: umbral_pre::KeyFrag) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for KeyFrag {
-    fn name() -> &'static str {
-        "KeyFrag"
     }
 }
 
@@ -570,7 +532,7 @@ impl PyObjectProtocol for KeyFrag {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -580,15 +542,9 @@ pub struct VerifiedKeyFrag {
     backend: umbral_pre::VerifiedKeyFrag,
 }
 
-impl AsSerializableBackend<umbral_pre::VerifiedKeyFrag> for VerifiedKeyFrag {
+impl AsBackend<umbral_pre::VerifiedKeyFrag> for VerifiedKeyFrag {
     fn as_backend(&self) -> &umbral_pre::VerifiedKeyFrag {
         &self.backend
-    }
-}
-
-impl HasName for VerifiedKeyFrag {
-    fn name() -> &'static str {
-        "VerifiedKeyFrag"
     }
 }
 
@@ -598,7 +554,7 @@ impl VerifiedKeyFrag {
     pub fn from_verified_bytes(data: &[u8]) -> PyResult<Self> {
         umbral_pre::VerifiedKeyFrag::from_verified_bytes(data)
             .map(|vkfrag| Self { backend: vkfrag })
-            .map_err(map_serialization_err::<VerifiedKeyFrag>)
+            .map_err(map_deserialization_err::<umbral_pre::VerifiedKeyFrag>)
     }
 
     #[staticmethod]
@@ -622,7 +578,7 @@ impl PyObjectProtocol for VerifiedKeyFrag {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -660,21 +616,15 @@ pub struct CapsuleFrag {
     backend: umbral_pre::CapsuleFrag,
 }
 
-impl AsSerializableBackend<umbral_pre::CapsuleFrag> for CapsuleFrag {
+impl AsBackend<umbral_pre::CapsuleFrag> for CapsuleFrag {
     fn as_backend(&self) -> &umbral_pre::CapsuleFrag {
         &self.backend
     }
 }
 
-impl FromSerializableBackend<umbral_pre::CapsuleFrag> for CapsuleFrag {
+impl FromBackend<umbral_pre::CapsuleFrag> for CapsuleFrag {
     fn from_backend(backend: umbral_pre::CapsuleFrag) -> Self {
         Self { backend }
-    }
-}
-
-impl HasName for CapsuleFrag {
-    fn name() -> &'static str {
-        "CapsuleFrag"
     }
 }
 
@@ -733,7 +683,7 @@ impl PyObjectProtocol for CapsuleFrag {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 
@@ -743,15 +693,9 @@ pub struct VerifiedCapsuleFrag {
     backend: umbral_pre::VerifiedCapsuleFrag,
 }
 
-impl AsSerializableBackend<umbral_pre::VerifiedCapsuleFrag> for VerifiedCapsuleFrag {
+impl AsBackend<umbral_pre::VerifiedCapsuleFrag> for VerifiedCapsuleFrag {
     fn as_backend(&self) -> &umbral_pre::VerifiedCapsuleFrag {
         &self.backend
-    }
-}
-
-impl HasName for VerifiedCapsuleFrag {
-    fn name() -> &'static str {
-        "VerifiedCapsuleFrag"
     }
 }
 
@@ -770,7 +714,7 @@ impl PyObjectProtocol for VerifiedCapsuleFrag {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        hexstr(self)
+        Ok(format!("{}", self.backend))
     }
 }
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -36,7 +36,7 @@ where
 
 fn map_deserialization_err<T: HasTypeName>(err: DeserializationError) -> PyErr {
     match err {
-        DeserializationError::ConstructionFailure => {
+        DeserializationError::ConstructionFailure(_) => {
             PyValueError::new_err(format!("Failed to deserialize a {} object", T::type_name()))
         }
         DeserializationError::TooManyBytes => {

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -39,11 +39,8 @@ fn map_deserialization_err<T: HasTypeName>(err: DeserializationError) -> PyErr {
         DeserializationError::ConstructionFailure(_) => {
             PyValueError::new_err(format!("Failed to deserialize a {} object", T::type_name()))
         }
-        DeserializationError::TooManyBytes => {
-            PyValueError::new_err("The given bytestring is too long")
-        }
-        DeserializationError::NotEnoughBytes => {
-            PyValueError::new_err("The given bytestring is too short")
+        DeserializationError::SizeMismatch(_) => {
+            PyValueError::new_err("The given bytestring has an incorrect size")
         }
     }
 }

--- a/umbral-pre-python/umbral_pre/__init__.py
+++ b/umbral-pre-python/umbral_pre/__init__.py
@@ -9,7 +9,6 @@ from ._umbral import (
     VerifiedKeyFrag,
     CapsuleFrag,
     VerifiedCapsuleFrag,
-    GenericError,
     VerificationError,
     encrypt,
     decrypt_original,

--- a/umbral-pre-wasm/Cargo.toml
+++ b/umbral-pre-wasm/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 umbral-pre = { path = "../umbral-pre" }
-wasm-bindgen = "0.2.63"
-console_error_panic_hook = { version = "0.1" } # TODO (#16): make conditional
+wasm-bindgen = "0.2.74"
+js-sys = "0.3.51"
 wee_alloc = "0.4"
 
 [package.metadata.wasm-pack.profile.release]

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -20,14 +20,14 @@ let dec = new TextDecoder("utf-8");
 
 // Key Generation (on Alice's side)
 let alice_sk = umbral.SecretKey.random();
-let alice_pk = umbral.PublicKey.from_secret_key(alice_sk);
+let alice_pk = umbral.PublicKey.fromSecretKey(alice_sk);
 let signing_sk = umbral.SecretKey.random();
 let signer = new umbral.Signer(signing_sk);
-let verifying_pk = umbral.PublicKey.from_secret_key(signing_sk);
+let verifying_pk = umbral.PublicKey.fromSecretKey(signing_sk);
 
 // Key Generation (on Bob's side)
 let bob_sk = umbral.SecretKey.random();
-let bob_pk = umbral.PublicKey.from_secret_key(bob_sk);
+let bob_pk = umbral.PublicKey.fromSecretKey(bob_sk);
 
 // Now let's encrypt data with Alice's public key.
 // Invocation of `encrypt()` returns both the ciphertext and a capsule.
@@ -46,7 +46,7 @@ let capsule = result.capsule;
 // Since data was encrypted with Alice's public key, Alice can open the capsule
 // and decrypt the ciphertext with her private key.
 
-let plaintext_alice = umbral.decrypt_original(alice_sk, capsule, ciphertext);
+let plaintext_alice = umbral.decryptOriginal(alice_sk, capsule, ciphertext);
 console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() failed");
 
 // When Alice wants to grant Bob access to open her encrypted messages,
@@ -55,7 +55,7 @@ console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() fai
 
 let n = 3; // how many fragments to create
 let m = 2; // how many should be enough to decrypt
-let kfrags = umbral.generate_kfrags(
+let kfrags = umbral.generateKFrags(
     alice_sk, bob_pk, signer, m, n, true, true);
 
 // Bob asks several Ursulas to re-encrypt the capsule so he can open it.
@@ -80,9 +80,9 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 // wasm-pack does not support taking arrays as arguments,
 // so we build a capsule+cfrags object before decryption.
 let plaintext_bob = capsule
-    .with_cfrag(cfrag0)
-    .with_cfrag(cfrag1)
-    .decrypt_reencrypted(bob_sk, alice_pk, ciphertext);
+    .withCFrag(cfrag0)
+    .withCFrag(cfrag1)
+    .decryptReencrypted(bob_sk, alice_pk, ciphertext);
 
 console.assert(dec.decode(plaintext_bob) == plaintext, "decrypt_reencrypted() failed");
 ```

--- a/umbral-pre-wasm/example/index.js
+++ b/umbral-pre-wasm/example/index.js
@@ -9,14 +9,14 @@ let dec = new TextDecoder("utf-8");
 
 // Key Generation (on Alice's side)
 let alice_sk = umbral.SecretKey.random();
-let alice_pk = umbral.PublicKey.from_secret_key(alice_sk);
+let alice_pk = umbral.PublicKey.fromSecretKey(alice_sk);
 let signing_sk = umbral.SecretKey.random();
 let signer = new umbral.Signer(signing_sk);
-let verifying_pk = umbral.PublicKey.from_secret_key(signing_sk);
+let verifying_pk = umbral.PublicKey.fromSecretKey(signing_sk);
 
 // Key Generation (on Bob's side)
 let bob_sk = umbral.SecretKey.random();
-let bob_pk = umbral.PublicKey.from_secret_key(bob_sk);
+let bob_pk = umbral.PublicKey.fromSecretKey(bob_sk);
 
 // Now let's encrypt data with Alice's public key.
 // Invocation of `encrypt()` returns both the ciphertext and a capsule.
@@ -35,7 +35,7 @@ let capsule = result.capsule;
 // Since data was encrypted with Alice's public key, Alice can open the capsule
 // and decrypt the ciphertext with her private key.
 
-let plaintext_alice = umbral.decrypt_original(alice_sk, capsule, ciphertext);
+let plaintext_alice = umbral.decryptOriginal(alice_sk, capsule, ciphertext);
 console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() failed");
 
 // When Alice wants to grant Bob access to open her encrypted messages,
@@ -44,7 +44,7 @@ console.assert(dec.decode(plaintext_alice) == plaintext, "decrypt_original() fai
 
 let n = 3; // how many fragments to create
 let m = 2; // how many should be enough to decrypt
-let kfrags = umbral.generate_kfrags(
+let kfrags = umbral.generateKFrags(
     alice_sk, bob_pk, signer, m, n,
     true, // add the delegating key (alice_pk) to the signature
     true, // add the receiving key (bob_pk) to the signature
@@ -75,8 +75,8 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 // wasm-pack does not support taking arrays as arguments,
 // so we build a capsule+cfrags object before decryption.
 let plaintext_bob = capsule
-    .with_cfrag(cfrag0)
-    .with_cfrag(cfrag1)
-    .decrypt_reencrypted(bob_sk, alice_pk, ciphertext);
+    .withCFrag(cfrag0)
+    .withCFrag(cfrag1)
+    .decryptReencrypted(bob_sk, alice_pk, ciphertext);
 
 console.assert(dec.decode(plaintext_bob) == plaintext, "decrypt_reencrypted() failed");

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -102,6 +102,7 @@ pub struct PublicKey(umbral_pre::PublicKey);
 #[wasm_bindgen]
 impl PublicKey {
     /// Generates a secret key using the default RNG and returns it.
+    #[wasm_bindgen(js_name = fromSecretKey)]
     pub fn from_secret_key(secret_key: &SecretKey) -> Self {
         Self(umbral_pre::PublicKey::from_secret_key(&secret_key.0))
     }
@@ -143,6 +144,7 @@ impl Signer {
         Signature(self.0.sign(message))
     }
 
+    #[wasm_bindgen(js_name = verifyingKey)]
     pub fn verifying_key(&self) -> PublicKey {
         PublicKey(self.0.verifying_key())
     }
@@ -199,7 +201,7 @@ impl Capsule {
     // TODO (#23): have to add cfrags one by one since `wasm_bindgen` currently does not support
     // Vec<CustomStruct> as a parameter.
     // Will probably be fixed along with https://github.com/rustwasm/wasm-bindgen/issues/111
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = withCFrag)]
     pub fn with_cfrag(&self, cfrag: &VerifiedCapsuleFrag) -> CapsuleWithFrags {
         CapsuleWithFrags {
             capsule: *self,
@@ -308,7 +310,7 @@ pub struct CapsuleWithFrags {
 
 #[wasm_bindgen]
 impl CapsuleWithFrags {
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = withCFrag)]
     pub fn with_cfrag(&self, cfrag: &VerifiedCapsuleFrag) -> CapsuleWithFrags {
         let mut new_cfrags = self.cfrags.clone();
         new_cfrags.push(cfrag.clone());
@@ -318,7 +320,7 @@ impl CapsuleWithFrags {
         }
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = decryptReencrypted)]
     pub fn decrypt_reencrypted(
         &self,
         receiving_sk: &SecretKey,
@@ -369,7 +371,7 @@ pub fn encrypt(delegating_pk: &PublicKey, plaintext: &[u8]) -> Result<Encryption
         .map_err(map_js_err)
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = decryptOriginal)]
 pub fn decrypt_original(
     delegating_sk: &SecretKey,
     capsule: &Capsule,
@@ -395,7 +397,7 @@ impl KeyFrag {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = verifyWithDelegatingKey)]
     pub fn verify_with_delegating_key(
         &self,
         verifying_pk: &PublicKey,
@@ -409,7 +411,7 @@ impl KeyFrag {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = verifyWithReceivingKey)]
     pub fn verify_with_receiving_key(
         &self,
         verifying_pk: &PublicKey,
@@ -423,7 +425,7 @@ impl KeyFrag {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = verifyWithDelegatingAndReceivingKeys)]
     pub fn verify_with_delegating_and_receiving_keys(
         &self,
         verifying_pk: &PublicKey,
@@ -471,6 +473,7 @@ pub struct VerifiedKeyFrag(umbral_pre::VerifiedKeyFrag);
 
 #[wasm_bindgen]
 impl VerifiedKeyFrag {
+    #[wasm_bindgen(js_name = fromVerifiedBytes)]
     pub fn from_verified_bytes(bytes: &[u8]) -> Result<VerifiedKeyFrag, JsValue> {
         umbral_pre::VerifiedKeyFrag::from_verified_bytes(bytes)
             .map(Self)
@@ -494,7 +497,7 @@ impl VerifiedKeyFrag {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = generateKFrags)]
 pub fn generate_kfrags(
     delegating_sk: &SecretKey,
     receiving_pk: &PublicKey,

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -24,8 +24,7 @@ use umbral_pre::{
 fn map_deserialization_err(err: DeserializationError) -> JsValue {
     match err {
         DeserializationError::ConstructionFailure(_) => Error::new("Failed to deserialize object"),
-        DeserializationError::TooManyBytes => Error::new("The given bytestring is too long"),
-        DeserializationError::NotEnoughBytes => Error::new("The given bytestring is too short"),
+        DeserializationError::SizeMismatch(_) => Error::new("The given bytestring has an incorrect size"),
     }
     .into()
 }

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -1,16 +1,46 @@
 #![no_std]
 
-extern crate alloc;
-
 // Use `wee_alloc` as the global allocator.
 extern crate wee_alloc;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+extern crate alloc;
 
 use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
 use alloc::{vec, vec::Vec};
+
+use js_sys::Error;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+use umbral_pre::{
+    CapsuleFragVerificationError, DecryptionError, DeserializableFromArray, DeserializationError,
+    EncryptionError, KeyFragVerificationError, OpenReencryptedError, ReencryptionError,
+    SerializableToArray,
+};
+
+fn map_deserialization_err(err: DeserializationError) -> JsValue {
+    match err {
+        DeserializationError::ConstructionFailure(_) => Error::new("Failed to deserialize object"),
+        DeserializationError::TooManyBytes => Error::new("The given bytestring is too long"),
+        DeserializationError::NotEnoughBytes => Error::new("The given bytestring is too short"),
+    }
+    .into()
+}
+
+fn map_decryption_err(err: DecryptionError) -> JsValue {
+    match err {
+        DecryptionError::CiphertextTooShort => Error::new("The ciphertext must include the nonce"),
+        DecryptionError::AuthenticationFailed => Error::new(
+            "Decryption of ciphertext failed: \
+            either someone tampered with the ciphertext or \
+            you are using an incorrect decryption key.",
+        ),
+    }
+    .into()
+}
 
 #[wasm_bindgen]
 pub struct SecretKey(umbral_pre::SecretKey);
@@ -19,8 +49,29 @@ pub struct SecretKey(umbral_pre::SecretKey);
 impl SecretKey {
     /// Generates a secret key using the default RNG and returns it.
     pub fn random() -> Self {
-        console_error_panic_hook::set_once(); // TODO (#16): find a better place to initialize it
         Self(umbral_pre::SecretKey::random())
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<SecretKey, JsValue> {
+        umbral_pre::SecretKey::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &SecretKey) -> bool {
+        self.0 == other.0
     }
 }
 
@@ -32,6 +83,28 @@ impl PublicKey {
     /// Generates a secret key using the default RNG and returns it.
     pub fn from_secret_key(secret_key: &SecretKey) -> Self {
         Self(umbral_pre::PublicKey::from_secret_key(&secret_key.0))
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<PublicKey, JsValue> {
+        umbral_pre::PublicKey::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &PublicKey) -> bool {
+        self.0 == other.0
     }
 }
 
@@ -52,6 +125,16 @@ impl Signer {
     pub fn verifying_key(&self) -> PublicKey {
         PublicKey(self.0.verifying_key())
     }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &Signer) -> bool {
+        self.0 == other.0
+    }
 }
 
 #[wasm_bindgen]
@@ -61,6 +144,28 @@ pub struct Signature(umbral_pre::Signature);
 impl Signature {
     pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
         self.0.verify(&verifying_key.0, message)
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<Signature, JsValue> {
+        umbral_pre::Signature::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &Signature) -> bool {
+        self.0 == other.0
     }
 }
 
@@ -80,6 +185,28 @@ impl Capsule {
             cfrags: vec![cfrag.clone()],
         }
     }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<Capsule, JsValue> {
+        umbral_pre::Capsule::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &Capsule) -> bool {
+        self.0 == other.0
+    }
 }
 
 #[wasm_bindgen]
@@ -95,23 +222,72 @@ impl CapsuleFrag {
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
-    ) -> VerifiedCapsuleFrag {
-        VerifiedCapsuleFrag(
-            self.0
-                .verify(
-                    &capsule.0,
-                    &verifying_pk.0,
-                    &delegating_pk.0,
-                    &receiving_pk.0,
-                )
-                .unwrap(),
-        )
+    ) -> Result<VerifiedCapsuleFrag, JsValue> {
+        self.0
+            .verify(
+                &capsule.0,
+                &verifying_pk.0,
+                &delegating_pk.0,
+                &receiving_pk.0,
+            )
+            .map(VerifiedCapsuleFrag)
+            .map_err(|err| {
+                match err {
+                    CapsuleFragVerificationError::IncorrectKeyFragSignature => {
+                        Error::new("Invalid KeyFrag signature")
+                    }
+                    CapsuleFragVerificationError::IncorrectReencryption => {
+                        Error::new("Failed to verify reencryption proof")
+                    }
+                }
+                .into()
+            })
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<CapsuleFrag, JsValue> {
+        umbral_pre::CapsuleFrag::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &CapsuleFrag) -> bool {
+        self.0 == other.0
     }
 }
 
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct VerifiedCapsuleFrag(umbral_pre::VerifiedCapsuleFrag);
+
+#[wasm_bindgen]
+impl VerifiedCapsuleFrag {
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &VerifiedCapsuleFrag) -> bool {
+        self.0 == other.0
+    }
+}
 
 #[wasm_bindgen]
 pub struct CapsuleWithFrags {
@@ -137,7 +313,7 @@ impl CapsuleWithFrags {
         receiving_sk: &SecretKey,
         delegating_pk: &PublicKey,
         ciphertext: &[u8],
-    ) -> Option<Box<[u8]>> {
+    ) -> Result<Box<[u8]>, JsValue> {
         let backend_cfrags: Vec<umbral_pre::VerifiedCapsuleFrag> =
             self.cfrags.iter().cloned().map(|x| x.0).collect();
         umbral_pre::decrypt_reencrypted(
@@ -147,7 +323,22 @@ impl CapsuleWithFrags {
             backend_cfrags.as_slice(),
             ciphertext,
         )
-        .ok()
+        .map_err(|err| match err {
+            ReencryptionError::OnOpen(err) => match err {
+                OpenReencryptedError::NoCapsuleFrags => Error::new("Empty CapsuleFrag sequence"),
+                OpenReencryptedError::MismatchedCapsuleFrags => {
+                    Error::new("CapsuleFrags are not pairwise consistent")
+                }
+                OpenReencryptedError::RepeatingCapsuleFrags => {
+                    Error::new("Some of the CapsuleFrags are repeated")
+                }
+                // Will be removed when #39 is fixed
+                OpenReencryptedError::ZeroHash => Error::new("An internally hashed value is zero"),
+                OpenReencryptedError::ValidationFailed => Error::new("Internal validation failed"),
+            }
+            .into(),
+            ReencryptionError::OnDecryption(err) => map_decryption_err(err),
+        })
     }
 }
 
@@ -175,10 +366,18 @@ impl EncryptionResult {
 }
 
 #[wasm_bindgen]
-pub fn encrypt(delegating_pk: &PublicKey, plaintext: &[u8]) -> Option<EncryptionResult> {
+pub fn encrypt(delegating_pk: &PublicKey, plaintext: &[u8]) -> Result<EncryptionResult, JsValue> {
     let backend_pk = delegating_pk.0;
-    let (capsule, ciphertext) = umbral_pre::encrypt(&backend_pk, plaintext).unwrap();
-    Some(EncryptionResult::new(ciphertext, Capsule(capsule)))
+    umbral_pre::encrypt(&backend_pk, plaintext)
+        .map(|(capsule, ciphertext)| EncryptionResult::new(ciphertext, Capsule(capsule)))
+        .map_err(|err| {
+            match err {
+                EncryptionError::PlaintextTooLarge => {
+                    Error::new("Plaintext is too large to encrypt")
+                }
+            }
+            .into()
+        })
 }
 
 #[wasm_bindgen]
@@ -186,8 +385,24 @@ pub fn decrypt_original(
     delegating_sk: &SecretKey,
     capsule: &Capsule,
     ciphertext: &[u8],
-) -> Box<[u8]> {
-    umbral_pre::decrypt_original(&delegating_sk.0, &capsule.0, ciphertext).unwrap()
+) -> Result<Box<[u8]>, JsValue> {
+    umbral_pre::decrypt_original(&delegating_sk.0, &capsule.0, ciphertext)
+        .map_err(map_decryption_err)
+}
+
+fn map_kfrag_verification_err(err: KeyFragVerificationError) -> JsValue {
+    match err {
+            KeyFragVerificationError::IncorrectCommitment => Error::new("Invalid kfrag commitment"),
+            KeyFragVerificationError::DelegatingKeyNotProvided => {
+                Error::new("A signature of a delegating key was included in this kfrag but the key is not provided")
+            },
+            KeyFragVerificationError::ReceivingKeyNotProvided => {
+                Error::new("A signature of a receiving key was included in this kfrag, but the key is not provided")
+            },
+            KeyFragVerificationError::IncorrectSignature => {
+                Error::new("Failed to verify the kfrag signature")
+            },
+        }.into()
 }
 
 #[wasm_bindgen]
@@ -200,8 +415,11 @@ impl KeyFrag {
     // So we have to use 4 functions instead of 1. Yikes.
 
     #[wasm_bindgen]
-    pub fn verify(&self, verifying_pk: &PublicKey) -> VerifiedKeyFrag {
-        VerifiedKeyFrag(self.0.verify(&verifying_pk.0, None, None).unwrap())
+    pub fn verify(&self, verifying_pk: &PublicKey) -> Result<VerifiedKeyFrag, JsValue> {
+        self.0
+            .verify(&verifying_pk.0, None, None)
+            .map(VerifiedKeyFrag)
+            .map_err(map_kfrag_verification_err)
     }
 
     #[wasm_bindgen]
@@ -209,14 +427,13 @@ impl KeyFrag {
         &self,
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
-    ) -> VerifiedKeyFrag {
+    ) -> Result<VerifiedKeyFrag, JsValue> {
         let backend_delegating_pk = delegating_pk.0;
 
-        VerifiedKeyFrag(
-            self.0
-                .verify(&verifying_pk.0, Some(&backend_delegating_pk), None)
-                .unwrap(),
-        )
+        self.0
+            .verify(&verifying_pk.0, Some(&backend_delegating_pk), None)
+            .map(VerifiedKeyFrag)
+            .map_err(map_kfrag_verification_err)
     }
 
     #[wasm_bindgen]
@@ -224,14 +441,13 @@ impl KeyFrag {
         &self,
         verifying_pk: &PublicKey,
         receiving_pk: &PublicKey,
-    ) -> VerifiedKeyFrag {
+    ) -> Result<VerifiedKeyFrag, JsValue> {
         let backend_receiving_pk = receiving_pk.0;
 
-        VerifiedKeyFrag(
-            self.0
-                .verify(&verifying_pk.0, None, Some(&backend_receiving_pk))
-                .unwrap(),
-        )
+        self.0
+            .verify(&verifying_pk.0, None, Some(&backend_receiving_pk))
+            .map(VerifiedKeyFrag)
+            .map_err(map_kfrag_verification_err)
     }
 
     #[wasm_bindgen]
@@ -240,19 +456,40 @@ impl KeyFrag {
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
-    ) -> VerifiedKeyFrag {
+    ) -> Result<VerifiedKeyFrag, JsValue> {
         let backend_delegating_pk = delegating_pk.0;
         let backend_receiving_pk = receiving_pk.0;
 
-        VerifiedKeyFrag(
-            self.0
-                .verify(
-                    &verifying_pk.0,
-                    Some(&backend_delegating_pk),
-                    Some(&backend_receiving_pk),
-                )
-                .unwrap(),
-        )
+        self.0
+            .verify(
+                &verifying_pk.0,
+                Some(&backend_delegating_pk),
+                Some(&backend_receiving_pk),
+            )
+            .map(VerifiedKeyFrag)
+            .map_err(map_kfrag_verification_err)
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<KeyFrag, JsValue> {
+        umbral_pre::KeyFrag::from_bytes(data)
+            .map(Self)
+            .map_err(map_deserialization_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &KeyFrag) -> bool {
+        self.0 == other.0
     }
 }
 
@@ -261,10 +498,25 @@ pub struct VerifiedKeyFrag(umbral_pre::VerifiedKeyFrag);
 
 #[wasm_bindgen]
 impl VerifiedKeyFrag {
-    pub fn from_verified_bytes(bytes: &[u8]) -> Self {
+    pub fn from_verified_bytes(bytes: &[u8]) -> Result<VerifiedKeyFrag, JsValue> {
         umbral_pre::VerifiedKeyFrag::from_verified_bytes(bytes)
             .map(Self)
-            .unwrap()
+            .map_err(map_deserialization_err)
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &VerifiedKeyFrag) -> bool {
+        self.0 == other.0
     }
 }
 

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -56,6 +56,47 @@ impl SecretKey {
 }
 
 #[wasm_bindgen]
+pub struct SecretKeyFactory(umbral_pre::SecretKeyFactory);
+
+#[wasm_bindgen]
+impl SecretKeyFactory {
+    /// Generates a secret key factory using the default RNG and returns it.
+    pub fn random() -> Self {
+        Self(umbral_pre::SecretKeyFactory::random())
+    }
+
+    #[wasm_bindgen(js_name = secretKeyByLabel)]
+    pub fn secret_key_by_label(&self, label: &[u8]) -> Result<SecretKey, JsValue> {
+        self.0
+            .secret_key_by_label(label)
+            .map(SecretKey)
+            .map_err(map_js_err)
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.0.to_array().to_vec().into_boxed_slice()
+    }
+
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(data: &[u8]) -> Result<SecretKeyFactory, JsValue> {
+        umbral_pre::SecretKeyFactory::from_bytes(data)
+            .map(Self)
+            .map_err(map_js_err)
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn equals(&self, other: &SecretKeyFactory) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[wasm_bindgen]
 pub struct PublicKey(umbral_pre::PublicKey);
 
 #[wasm_bindgen]

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -14,6 +14,7 @@ k256 = { version = "0.8", default-features = false, features = ["ecdsa", "arithm
 sha2 = "0.9"
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = "0.11"
+hex = "0.4"
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -1,17 +1,19 @@
+use alloc::vec::Vec;
+use core::fmt;
+
+use generic_array::sequence::Concat;
+use generic_array::GenericArray;
+use typenum::op;
+
 use crate::capsule_frag::CapsuleFrag;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing_ds::{hash_capsule_points, hash_to_polynomial_arg, hash_to_shared_secret};
 use crate::keys::{PublicKey, SecretKey};
 use crate::params::Parameters;
 use crate::traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
+    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    SerializableToArray,
 };
-
-use alloc::vec::Vec;
-
-use generic_array::sequence::Concat;
-use generic_array::GenericArray;
-use typenum::op;
 
 /// Errors that can happen when opening a `Capsule` using reencrypted `CapsuleFrag` objects.
 #[derive(Debug, PartialEq)]
@@ -64,6 +66,18 @@ impl DeserializableFromArray for Capsule {
         let signature = CurveScalar::take_last(rest)?;
         Self::new_verified(point_e, point_v, signature)
             .ok_or(DeserializationError::ConstructionFailure)
+    }
+}
+
+impl HasTypeName for Capsule {
+    fn type_name() -> &'static str {
+        "Capsule"
+    }
+}
+
+impl fmt::Display for Capsule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public::<Self>(self, f)
     }
 }
 

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -64,7 +64,8 @@ impl DeserializableFromArray for Capsule {
         let (point_e, rest) = CurvePoint::take(*arr)?;
         let (point_v, rest) = CurvePoint::take(rest)?;
         let signature = CurveScalar::take_last(rest)?;
-        Self::new_verified(point_e, point_v, signature).ok_or(ConstructionError::GenericFailure)
+        Self::new_verified(point_e, point_v, signature)
+            .ok_or_else(|| ConstructionError::new("Capsule", "Self-verification failed"))
     }
 }
 

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -11,7 +11,7 @@ use crate::hashing_ds::{hash_capsule_points, hash_to_polynomial_arg, hash_to_sha
 use crate::keys::{PublicKey, SecretKey};
 use crate::params::Parameters;
 use crate::traits::{
-    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    fmt_public, ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
     SerializableToArray,
 };
 
@@ -60,12 +60,11 @@ impl SerializableToArray for Capsule {
 }
 
 impl DeserializableFromArray for Capsule {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let (point_e, rest) = CurvePoint::take(*arr)?;
         let (point_v, rest) = CurvePoint::take(rest)?;
         let signature = CurveScalar::take_last(rest)?;
-        Self::new_verified(point_e, point_v, signature)
-            .ok_or(DeserializationError::ConstructionFailure)
+        Self::new_verified(point_e, point_v, signature).ok_or(ConstructionError::GenericFailure)
     }
 }
 

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -34,6 +34,19 @@ pub enum OpenReencryptedError {
     ValidationFailed,
 }
 
+impl fmt::Display for OpenReencryptedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoCapsuleFrags => write!(f, "Empty CapsuleFrag sequence"),
+            Self::MismatchedCapsuleFrags => write!(f, "CapsuleFrags are not pairwise consistent"),
+            Self::RepeatingCapsuleFrags => write!(f, "Some of the CapsuleFrags are repeated"),
+            // Will be removed when #39 is fixed
+            Self::ZeroHash => write!(f, "An internally hashed value is zero"),
+            Self::ValidationFailed => write!(f, "Internal validation failed"),
+        }
+    }
+}
+
 /// Encapsulated symmetric key used to encrypt the plaintext.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Capsule {

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -1,15 +1,18 @@
+use core::fmt;
+
+use generic_array::sequence::Concat;
+use generic_array::GenericArray;
+use typenum::op;
+
 use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
 use crate::traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
+    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    SerializableToArray,
 };
-
-use generic_array::sequence::Concat;
-use generic_array::GenericArray;
-use typenum::op;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CapsuleFragProof {
@@ -149,6 +152,18 @@ impl DeserializableFromArray for CapsuleFrag {
     }
 }
 
+impl HasTypeName for CapsuleFrag {
+    fn type_name() -> &'static str {
+        "CapsuleFrag"
+    }
+}
+
+impl fmt::Display for CapsuleFrag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public::<Self>(self, f)
+    }
+}
+
 /// Possible errors that can be returned by [`CapsuleFrag::verify`].
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CapsuleFragVerificationError {
@@ -256,6 +271,18 @@ impl RepresentableAsArray for VerifiedCapsuleFrag {
 impl SerializableToArray for VerifiedCapsuleFrag {
     fn to_array(&self) -> GenericArray<u8, Self::Size> {
         self.cfrag.to_array()
+    }
+}
+
+impl HasTypeName for VerifiedCapsuleFrag {
+    fn type_name() -> &'static str {
+        "VerifiedCapsuleFrag"
+    }
+}
+
+impl fmt::Display for VerifiedCapsuleFrag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public::<Self>(self, f)
     }
 }
 

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -10,7 +10,7 @@ use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
 use crate::traits::{
-    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    fmt_public, ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
     SerializableToArray,
 };
 
@@ -47,7 +47,7 @@ impl SerializableToArray for CapsuleFragProof {
 }
 
 impl DeserializableFromArray for CapsuleFragProof {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let (point_e2, rest) = CurvePoint::take(*arr)?;
         let (point_v2, rest) = CurvePoint::take(rest)?;
         let (kfrag_commitment, rest) = CurvePoint::take(rest)?;
@@ -136,7 +136,7 @@ impl SerializableToArray for CapsuleFrag {
 }
 
 impl DeserializableFromArray for CapsuleFrag {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let (point_e1, rest) = CurvePoint::take(*arr)?;
         let (point_v1, rest) = CurvePoint::take(rest)?;
         let (kfrag_id, rest) = KeyFragID::take(rest)?;

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -173,6 +173,15 @@ pub enum CapsuleFragVerificationError {
     IncorrectReencryption,
 }
 
+impl fmt::Display for CapsuleFragVerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IncorrectKeyFragSignature => write!(f, "Invalid KeyFrag signature"),
+            Self::IncorrectReencryption => write!(f, "Failed to verify reencryption proof"),
+        }
+    }
+}
+
 impl CapsuleFrag {
     fn reencrypted(capsule: &Capsule, kfrag: &KeyFrag) -> Self {
         let rk = kfrag.key;

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -4,6 +4,7 @@
 
 use core::default::Default;
 use core::ops::{Add, Mul, Sub};
+
 use digest::Digest;
 use ecdsa::hazmat::FromDigest;
 use elliptic_curve::ff::PrimeField;
@@ -16,7 +17,8 @@ use rand_core::OsRng;
 use subtle::CtOption;
 
 use crate::traits::{
-    ConstructionError, DeserializableFromArray, RepresentableAsArray, SerializableToArray,
+    ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
+    SerializableToArray,
 };
 
 pub(crate) type CurveType = Secp256k1;
@@ -90,7 +92,13 @@ impl DeserializableFromArray for CurveScalar {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         Scalar::<CurveType>::from_repr(*arr)
             .map(Self)
-            .ok_or(ConstructionError::GenericFailure)
+            .ok_or_else(|| ConstructionError::new("CurveScalar", "Internal backend error"))
+    }
+}
+
+impl HasTypeName for CurveScalar {
+    fn type_name() -> &'static str {
+        "CurveScalar"
     }
 }
 
@@ -184,6 +192,13 @@ impl SerializableToArray for CurvePoint {
 
 impl DeserializableFromArray for CurvePoint {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
-        Self::from_compressed_array(arr).ok_or(ConstructionError::GenericFailure)
+        Self::from_compressed_array(arr)
+            .ok_or_else(|| ConstructionError::new("CurvePoint", "Internal backend error"))
+    }
+}
+
+impl HasTypeName for CurvePoint {
+    fn type_name() -> &'static str {
+        "CurvePoint"
     }
 }

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -16,7 +16,7 @@ use rand_core::OsRng;
 use subtle::CtOption;
 
 use crate::traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
+    ConstructionError, DeserializableFromArray, RepresentableAsArray, SerializableToArray,
 };
 
 pub(crate) type CurveType = Secp256k1;
@@ -87,10 +87,10 @@ impl SerializableToArray for CurveScalar {
 }
 
 impl DeserializableFromArray for CurveScalar {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         Scalar::<CurveType>::from_repr(*arr)
             .map(Self)
-            .ok_or(DeserializationError::ConstructionFailure)
+            .ok_or(ConstructionError::GenericFailure)
     }
 }
 
@@ -183,7 +183,7 @@ impl SerializableToArray for CurvePoint {
 }
 
 impl DeserializableFromArray for CurvePoint {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
-        Self::from_compressed_array(arr).ok_or(DeserializationError::ConstructionFailure)
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
+        Self::from_compressed_array(arr).ok_or(ConstructionError::GenericFailure)
     }
 }

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::fmt;
 
 use aead::{Aead, AeadCore, Payload};
 use chacha20poly1305::aead::NewAead;
@@ -17,6 +18,14 @@ pub enum EncryptionError {
     PlaintextTooLarge,
 }
 
+impl fmt::Display for EncryptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PlaintextTooLarge => write!(f, "Plaintext is too large to encrypt"),
+        }
+    }
+}
+
 /// Errors that can happend during symmetric decryption.
 #[derive(Debug, PartialEq)]
 pub enum DecryptionError {
@@ -28,6 +37,20 @@ pub enum DecryptionError {
     /// - the ciphertext is modified or cut short,
     /// - an incorrect authentication data is provided on decryption.
     AuthenticationFailed,
+}
+
+impl fmt::Display for DecryptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CiphertextTooShort => write!(f, "The ciphertext must include the nonce"),
+            Self::AuthenticationFailed => write!(
+                f,
+                "Decryption of ciphertext failed: \
+                either someone tampered with the ciphertext or \
+                you are using an incorrect decryption key."
+            ),
+        }
+    }
 }
 
 pub(crate) fn kdf<T: ArrayLength<u8>>(

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -1,18 +1,20 @@
-use crate::curve::{CurvePoint, CurveScalar};
-use crate::hashing_ds::{hash_to_polynomial_arg, hash_to_shared_secret, kfrag_signature_message};
-use crate::keys::{PublicKey, SecretKey, Signature, Signer};
-use crate::params::Parameters;
-use crate::traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
-};
-
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::fmt;
 
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
 use rand_core::{OsRng, RngCore};
 use typenum::{op, U32};
+
+use crate::curve::{CurvePoint, CurveScalar};
+use crate::hashing_ds::{hash_to_polynomial_arg, hash_to_shared_secret, kfrag_signature_message};
+use crate::keys::{PublicKey, SecretKey, Signature, Signer};
+use crate::params::Parameters;
+use crate::traits::{
+    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    SerializableToArray,
+};
 
 #[allow(clippy::upper_case_acronyms)]
 type KeyFragIDSize = U32;
@@ -196,6 +198,18 @@ impl DeserializableFromArray for KeyFrag {
     }
 }
 
+impl HasTypeName for KeyFrag {
+    fn type_name() -> &'static str {
+        "KeyFrag"
+    }
+}
+
+impl fmt::Display for KeyFrag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public::<Self>(self, f)
+    }
+}
+
 /// Possible errors that can be returned by [`KeyFrag::verify`].
 #[derive(Debug, PartialEq)]
 pub enum KeyFragVerificationError {
@@ -318,6 +332,18 @@ impl RepresentableAsArray for VerifiedKeyFrag {
 impl SerializableToArray for VerifiedKeyFrag {
     fn to_array(&self) -> GenericArray<u8, Self::Size> {
         self.kfrag.to_array()
+    }
+}
+
+impl HasTypeName for VerifiedKeyFrag {
+    fn type_name() -> &'static str {
+        "VerifiedKeyFrag"
+    }
+}
+
+impl fmt::Display for VerifiedKeyFrag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public::<Self>(self, f)
     }
 }
 

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -225,6 +225,17 @@ pub enum KeyFragVerificationError {
     IncorrectSignature,
 }
 
+impl fmt::Display for KeyFragVerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IncorrectCommitment => write!(f, "Invalid kfrag commitment"),
+            Self::DelegatingKeyNotProvided => write!(f, "A signature of a delegating key was included in this kfrag but the key is not provided"),
+            Self::ReceivingKeyNotProvided => write!(f, "A signature of a receiving key was included in this kfrag, but the key is not provided"),
+            Self::IncorrectSignature => write!(f, "Failed to verify the kfrag signature"),
+        }
+    }
+}
+
 impl KeyFrag {
     fn from_base(base: &KeyFragBase, sign_delegating_key: bool, sign_receiving_key: bool) -> Self {
         let kfrag_id = KeyFragID::random();

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -12,8 +12,8 @@ use crate::hashing_ds::{hash_to_polynomial_arg, hash_to_shared_secret, kfrag_sig
 use crate::keys::{PublicKey, SecretKey, Signature, Signer};
 use crate::params::Parameters;
 use crate::traits::{
-    fmt_public, DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
-    SerializableToArray,
+    fmt_public, ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
+    RepresentableAsArray, SerializableToArray,
 };
 
 #[allow(clippy::upper_case_acronyms)]
@@ -48,7 +48,7 @@ impl SerializableToArray for KeyFragID {
 }
 
 impl DeserializableFromArray for KeyFragID {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         Ok(Self(*arr))
     }
 }
@@ -84,7 +84,7 @@ impl SerializableToArray for KeyFragProof {
 }
 
 impl DeserializableFromArray for KeyFragProof {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let (commitment, rest) = CurvePoint::take(*arr)?;
         let (signature_for_proxy, rest) = Signature::take(rest)?;
         let (signature_for_receiver, rest) = Signature::take(rest)?;
@@ -182,7 +182,7 @@ impl SerializableToArray for KeyFrag {
 }
 
 impl DeserializableFromArray for KeyFrag {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let params = Parameters::new();
         let (id, rest) = KeyFragID::take(*arr)?;
         let (key, rest) = CurveScalar::take(rest)?;

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -37,7 +37,7 @@ impl DeserializableFromArray for Signature {
         // and if it is not normalized, verification will fail.
         BackendSignature::<CurveType>::from_bytes(arr.as_slice())
             .map(Self)
-            .or(Err(ConstructionError::GenericFailure))
+            .map_err(|_| ConstructionError::new("Signature", "Internal backend error"))
     }
 }
 
@@ -119,7 +119,7 @@ impl DeserializableFromArray for SecretKey {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         BackendSecretKey::<CurveType>::from_bytes(arr.as_slice())
             .map(Self)
-            .or(Err(ConstructionError::GenericFailure))
+            .map_err(|_| ConstructionError::new("SecretKey", "Internal backend error"))
     }
 }
 
@@ -213,9 +213,9 @@ impl SerializableToArray for PublicKey {
 impl DeserializableFromArray for PublicKey {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let cp = CurvePoint::from_array(&arr)?;
-        let backend_pk = BackendPublicKey::<CurveType>::from_affine(cp.to_affine_point())
-            .or(Err(ConstructionError::GenericFailure))?;
-        Ok(Self(backend_pk))
+        BackendPublicKey::<CurveType>::from_affine(cp.to_affine_point())
+            .map(Self)
+            .map_err(|_| ConstructionError::new("PublicKey", "Internal backend error"))
     }
 }
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::fmt;
 
 use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use ecdsa::{Signature as BackendSignature, SignatureSize, SigningKey, VerifyingKey};
@@ -12,7 +13,8 @@ use crate::curve::{BackendNonZeroScalar, CurvePoint, CurveScalar, CurveType};
 use crate::dem::kdf;
 use crate::hashing::{BackendDigest, Hash, ScalarDigest};
 use crate::traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
+    fmt_public, fmt_secret, DeserializableFromArray, DeserializationError, HasTypeName,
+    RepresentableAsArray, SerializableToArray,
 };
 
 /// ECDSA signature object.
@@ -44,6 +46,18 @@ impl Signature {
     /// The message is hashed internally.
     pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
         verifying_key.verify_digest(digest_for_signing(message), &self)
+    }
+}
+
+impl HasTypeName for Signature {
+    fn type_name() -> &'static str {
+        "Signature"
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public(self, f)
     }
 }
 
@@ -109,6 +123,18 @@ impl DeserializableFromArray for SecretKey {
     }
 }
 
+impl HasTypeName for SecretKey {
+    fn type_name() -> &'static str {
+        "SecretKey"
+    }
+}
+
+impl fmt::Display for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_secret::<Self>(f)
+    }
+}
+
 fn digest_for_signing(message: &[u8]) -> BackendDigest {
     Hash::new().chain_bytes(message).digest()
 }
@@ -133,6 +159,18 @@ impl Signer {
     /// Returns the public key that can be used to verify the signatures produced by this signer.
     pub fn verifying_key(&self) -> PublicKey {
         PublicKey::from_secret_key(&self.0)
+    }
+}
+
+impl HasTypeName for Signer {
+    fn type_name() -> &'static str {
+        "Signer"
+    }
+}
+
+impl fmt::Display for Signer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_secret::<Self>(f)
     }
 }
 
@@ -178,6 +216,18 @@ impl DeserializableFromArray for PublicKey {
         let backend_pk = BackendPublicKey::<CurveType>::from_affine(cp.to_affine_point())
             .or(Err(DeserializationError::ConstructionFailure))?;
         Ok(Self(backend_pk))
+    }
+}
+
+impl HasTypeName for PublicKey {
+    fn type_name() -> &'static str {
+        "PublicKey"
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_public(self, f)
     }
 }
 
@@ -236,6 +286,18 @@ impl SerializableToArray for SecretKeyFactory {
 impl DeserializableFromArray for SecretKeyFactory {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
         Ok(Self(*arr))
+    }
+}
+
+impl HasTypeName for SecretKeyFactory {
+    fn type_name() -> &'static str {
+        "SecretKeyFactory"
+    }
+}
+
+impl fmt::Display for SecretKeyFactory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_secret::<Self>(f)
     }
 }
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -13,7 +13,7 @@ use crate::curve::{BackendNonZeroScalar, CurvePoint, CurveScalar, CurveType};
 use crate::dem::kdf;
 use crate::hashing::{BackendDigest, Hash, ScalarDigest};
 use crate::traits::{
-    fmt_public, fmt_secret, DeserializableFromArray, DeserializationError, HasTypeName,
+    fmt_public, fmt_secret, ConstructionError, DeserializableFromArray, HasTypeName,
     RepresentableAsArray, SerializableToArray,
 };
 
@@ -32,12 +32,12 @@ impl SerializableToArray for Signature {
 }
 
 impl DeserializableFromArray for Signature {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         // Note that it will not normalize `s` automatically,
         // and if it is not normalized, verification will fail.
         BackendSignature::<CurveType>::from_bytes(arr.as_slice())
             .map(Self)
-            .or(Err(DeserializationError::ConstructionFailure))
+            .or(Err(ConstructionError::GenericFailure))
     }
 }
 
@@ -116,10 +116,10 @@ impl SerializableToArray for SecretKey {
 }
 
 impl DeserializableFromArray for SecretKey {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         BackendSecretKey::<CurveType>::from_bytes(arr.as_slice())
             .map(Self)
-            .or(Err(DeserializationError::ConstructionFailure))
+            .or(Err(ConstructionError::GenericFailure))
     }
 }
 
@@ -211,10 +211,10 @@ impl SerializableToArray for PublicKey {
 }
 
 impl DeserializableFromArray for PublicKey {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         let cp = CurvePoint::from_array(&arr)?;
         let backend_pk = BackendPublicKey::<CurveType>::from_affine(cp.to_affine_point())
-            .or(Err(DeserializationError::ConstructionFailure))?;
+            .or(Err(ConstructionError::GenericFailure))?;
         Ok(Self(backend_pk))
     }
 }
@@ -284,7 +284,7 @@ impl SerializableToArray for SecretKeyFactory {
 }
 
 impl DeserializableFromArray for SecretKeyFactory {
-    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, DeserializationError> {
+    fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
         Ok(Self(*arr))
     }
 }

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -239,6 +239,14 @@ pub enum SecretKeyFactoryError {
     ZeroHash,
 }
 
+impl fmt::Display for SecretKeyFactoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroHash => write!(f, "Resulting secret key is zero"),
+        }
+    }
+}
+
 type SecretKeyFactorySeedSize = U64; // the size of the seed material for key derivation
 type SecretKeyFactoryDerivedSize = U64; // the size of the derived key (before hashing to scalar)
 

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -125,5 +125,5 @@ pub use pre::{
 };
 pub use traits::{
     ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
-    RepresentableAsArray, SerializableToArray,
+    RepresentableAsArray, SerializableToArray, SizeMismatchError,
 };

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -124,5 +124,6 @@ pub use pre::{
     decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt, ReencryptionError,
 };
 pub use traits::{
-    DeserializableFromArray, DeserializationError, RepresentableAsArray, SerializableToArray,
+    DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
+    SerializableToArray,
 };

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -124,6 +124,6 @@ pub use pre::{
     decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt, ReencryptionError,
 };
 pub use traits::{
-    DeserializableFromArray, DeserializationError, HasTypeName, RepresentableAsArray,
-    SerializableToArray,
+    ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
+    RepresentableAsArray, SerializableToArray,
 };

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -1,5 +1,7 @@
 //! The high-level functional reencryption API.
 
+use core::fmt;
+
 use crate::capsule::{Capsule, OpenReencryptedError};
 use crate::capsule_frag::VerifiedCapsuleFrag;
 use crate::dem::{DecryptionError, EncryptionError, DEM};
@@ -17,6 +19,15 @@ pub enum ReencryptionError {
     OnOpen(OpenReencryptedError),
     /// An error when decrypting the ciphertext. See [`DecryptionError`] for the options.
     OnDecryption(DecryptionError),
+}
+
+impl fmt::Display for ReencryptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OnOpen(err) => write!(f, "Re-encryption error on open: {}", err),
+            Self::OnDecryption(err) => write!(f, "Re-encryption error on decryption: {}", err),
+        }
+    }
 }
 
 /// Encrypts the given plaintext message using a DEM scheme,

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -28,6 +28,16 @@ impl ConstructionError {
     }
 }
 
+impl fmt::Display for ConstructionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to construct a {} object: {}",
+            self.type_name, self.message
+        )
+    }
+}
+
 /// The provided bytestring is of an incorrect size.
 #[derive(Debug, PartialEq)]
 pub struct SizeMismatchError {
@@ -45,6 +55,16 @@ impl SizeMismatchError {
     }
 }
 
+impl fmt::Display for SizeMismatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Bytestring size mismatch: expected {} bytes, got {}",
+            self.expected_size, self.received_size
+        )
+    }
+}
+
 /// Errors that can happen during object deserialization.
 #[derive(Debug, PartialEq)]
 pub enum DeserializationError {
@@ -52,6 +72,15 @@ pub enum DeserializationError {
     ConstructionFailure(ConstructionError),
     /// The given bytestring is too short or too long.
     SizeMismatch(SizeMismatchError),
+}
+
+impl fmt::Display for DeserializationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConstructionFailure(err) => write!(f, "{}", err),
+            Self::SizeMismatch(err) => write!(f, "{}", err),
+        }
+    }
 }
 
 /// A trait denoting that the object can be represented as an array of bytes

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -1,8 +1,10 @@
 use core::cmp::Ordering;
+use core::fmt;
 use core::ops::Sub;
+
 use generic_array::sequence::Split;
 use generic_array::{ArrayLength, GenericArray};
-use typenum::{Diff, Unsigned, U1};
+use typenum::{Diff, Unsigned, U1, U8};
 
 /// Errors that can happen during object deserialization.
 #[derive(Debug, PartialEq)]
@@ -102,6 +104,33 @@ impl DeserializableFromArray for bool {
             _ => Err(DeserializationError::ConstructionFailure),
         }
     }
+}
+
+/// A reflection trait providing access to the type's name.
+pub trait HasTypeName {
+    /// Returns a string with the name of the type
+    /// (intended for displaying to humans).
+    fn type_name() -> &'static str;
+    // There is `std::any::type_name()` available, but its format is not guaranteed;
+    // for example, it can prepend modules names.
+    // We just want the struct name, without any additions.
+}
+
+/// A `fmt` implementation for types with secret data.
+pub(crate) fn fmt_secret<T: HasTypeName>(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}:...", T::type_name())
+}
+
+/// A `fmt` implementation for types with public data.
+pub(crate) fn fmt_public<T>(obj: &T, f: &mut fmt::Formatter<'_>) -> fmt::Result
+where
+    T: HasTypeName + SerializableToArray + RepresentableAsArray,
+    <T as RepresentableAsArray>::Size: Sub<U8>,
+    Diff<<T as RepresentableAsArray>::Size, U8>: ArrayLength<u8>,
+{
+    let bytes = (*obj).to_array();
+    let (to_show, _): (GenericArray<u8, U8>, GenericArray<u8, _>) = bytes.split();
+    write!(f, "{}:{}", T::type_name(), hex::encode(to_show))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Based on top of #50

- Move `HasName` trait from Python bindings into the main library and rename it to `HasTypeName`
- Add a `Display` implementation for public types in the main library and use it in Python/WASM bindings (was formerly only implemented in Python bindings)
- Remove `GenericError` from Python bindings; in the cases where it is used it can be replaced by `ValueError`
- `from_array()` can only return a `ConstructionError` now, and not a size mismatch error (because the array size is already statically asserted by the compiler)
- Add `toBytes()/fromBytes()/toString()` methods to public objects in WASM bindings. Fixes #11 (if we decide to use some third-party serialization, like `protobuf`, it should be made a separate issue)
- Merge `DeserializationError::TooManyBytes/TooFewBytes` into a single `SizeMismatch`
- Retain more information in deserialization errors: the error message and the problem type for construction errors (helps when deserializing structures with nested elements), the expected/received bytestring size for size mismatch
- Raise exceptions properly instead of using `unwrap()` in WASM bindings. Fixes #14, fixes #16 (`console_error_panic_hook` is not needed anymore since there are no panics)
- Move error messages from Python bindings into `Display` implementations of error types in the main library, and use them from Python/WASM bindings to form exceptions
- Expose `SecretKeyFactory` in WASM bindings
- Use camel case for method names in WASM bindings