### PR TITLE
Add `SecretKey::public_key()` shortcut

### DIFF
--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -26,6 +26,10 @@ API reference
 
         Generates a new secret key.
 
+    .. py:method:: public_key() -> PublicKey
+
+        Returns a public key corresponding to this secret key.
+
     .. py:method:: __bytes__() -> bytes
 
         Serializes the object into a bytestring.
@@ -65,10 +69,6 @@ API reference
 .. py:class:: PublicKey
 
     An ``umbral-pre`` public key object.
-
-    .. py:staticmethod:: from_secret_key(sk: SecretKey) -> PublicKey
-
-        Creates a public key corresponding to the given secret key.
 
     .. py:method:: __bytes__() -> bytes
 

--- a/umbral-pre-python/example/example.py
+++ b/umbral-pre-python/example/example.py
@@ -7,14 +7,14 @@ import umbral_pre
 
 # Key Generation (on Alice's side)
 alice_sk = umbral_pre.SecretKey.random()
-alice_pk = umbral_pre.PublicKey.from_secret_key(alice_sk)
+alice_pk = alice_sk.public_key()
 signing_sk = umbral_pre.SecretKey.random()
 signer = umbral_pre.Signer(signing_sk)
-verifying_pk = umbral_pre.PublicKey.from_secret_key(signing_sk)
+verifying_pk = signing_sk.public_key()
 
 # Key Generation (on Bob's side)
 bob_sk = umbral_pre.SecretKey.random()
-bob_pk = umbral_pre.PublicKey.from_secret_key(bob_sk)
+bob_pk = bob_sk.public_key()
 
 # Now let's encrypt data with Alice's public key.
 # Invocation of `encrypt()` returns both the ciphertext

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -100,6 +100,12 @@ impl SecretKey {
         }
     }
 
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey {
+            backend: self.backend.public_key(),
+        }
+    }
+
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
@@ -208,13 +214,6 @@ impl FromBackend<umbral_pre::PublicKey> for PublicKey {
 
 #[pymethods]
 impl PublicKey {
-    #[staticmethod]
-    pub fn from_secret_key(sk: &SecretKey) -> Self {
-        Self {
-            backend: umbral_pre::PublicKey::from_secret_key(&sk.backend),
-        }
-    }
-
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -7,6 +7,9 @@ class SecretKey:
     def random() -> SecretKey:
         ...
 
+    def public_key(self) -> PublicKey:
+        ...
+
     @staticmethod
     def from_bytes() -> SecretKey:
         ...
@@ -35,10 +38,6 @@ class SecretKeyFactory:
 
 
 class PublicKey:
-
-    @staticmethod
-    def from_secret_key(sk: SecretKey) -> PublicKey:
-        ...
 
     @staticmethod
     def from_bytes() -> PublicKey:

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -20,14 +20,14 @@ let dec = new TextDecoder("utf-8");
 
 // Key Generation (on Alice's side)
 let alice_sk = umbral.SecretKey.random();
-let alice_pk = umbral.PublicKey.fromSecretKey(alice_sk);
+let alice_pk = alice_sk.publicKey();
 let signing_sk = umbral.SecretKey.random();
 let signer = new umbral.Signer(signing_sk);
-let verifying_pk = umbral.PublicKey.fromSecretKey(signing_sk);
+let verifying_pk = signing_sk.publicKey();
 
 // Key Generation (on Bob's side)
 let bob_sk = umbral.SecretKey.random();
-let bob_pk = umbral.PublicKey.fromSecretKey(bob_sk);
+let bob_pk = bob_sk.publicKey();
 
 // Now let's encrypt data with Alice's public key.
 // Invocation of `encrypt()` returns both the ciphertext and a capsule.

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -32,6 +32,12 @@ impl SecretKey {
         Self(umbral_pre::SecretKey::random())
     }
 
+    /// Generates a secret key using the default RNG and returns it.
+    #[wasm_bindgen(js_name = publicKey)]
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.public_key())
+    }
+
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.to_array().to_vec().into_boxed_slice()
@@ -101,12 +107,6 @@ pub struct PublicKey(umbral_pre::PublicKey);
 
 #[wasm_bindgen]
 impl PublicKey {
-    /// Generates a secret key using the default RNG and returns it.
-    #[wasm_bindgen(js_name = fromSecretKey)]
-    pub fn from_secret_key(secret_key: &SecretKey) -> Self {
-        Self(umbral_pre::PublicKey::from_secret_key(&secret_key.0))
-    }
-
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.to_array().to_vec().into_boxed_slice()

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -167,7 +167,7 @@ impl Capsule {
             return Err(OpenReencryptedError::MismatchedCapsuleFrags);
         }
 
-        let pub_key = PublicKey::from_secret_key(receiving_sk).to_point();
+        let pub_key = receiving_sk.public_key().to_point();
         let dh_point = &precursor * &receiving_sk.to_secret_scalar();
 
         // Combination of CFrags via Shamir's Secret Sharing reconstruction
@@ -232,14 +232,14 @@ mod tests {
 
     use super::{Capsule, OpenReencryptedError};
     use crate::{
-        encrypt, generate_kfrags, reencrypt, DeserializableFromArray, PublicKey, SecretKey,
+        encrypt, generate_kfrags, reencrypt, DeserializableFromArray, SecretKey,
         SerializableToArray, Signer,
     };
 
     #[test]
     fn test_serialize() {
         let delegating_sk = SecretKey::random();
-        let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let plaintext = b"peace at dawn";
         let (capsule, _ciphertext) = encrypt(&delegating_pk, plaintext).unwrap();
@@ -252,13 +252,13 @@ mod tests {
     #[test]
     fn test_open_reencrypted() {
         let delegating_sk = SecretKey::random();
-        let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let signing_sk = SecretKey::random();
         let signer = Signer::new(&signing_sk);
 
         let receiving_sk = SecretKey::random();
-        let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
+        let receiving_pk = receiving_sk.public_key();
 
         let (capsule, key_seed) = Capsule::from_public_key(&delegating_pk);
 

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -323,14 +323,14 @@ mod tests {
         Box<[VerifiedCapsuleFrag]>,
     ) {
         let delegating_sk = SecretKey::random();
-        let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let signing_sk = SecretKey::random();
         let signer = Signer::new(&signing_sk);
-        let verifying_pk = PublicKey::from_secret_key(&signing_sk);
+        let verifying_pk = signing_sk.public_key();
 
         let receiving_sk = SecretKey::random();
-        let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
+        let receiving_pk = receiving_sk.public_key();
 
         let plaintext = b"peace at dawn";
         let (capsule, _ciphertext) = encrypt(&delegating_pk, plaintext).unwrap();

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -399,7 +399,7 @@ impl KeyFragBase {
         let g = CurvePoint::generator();
         let params = Parameters::new();
 
-        let delegating_pk = PublicKey::from_secret_key(delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let receiving_pk_point = receiving_pk.to_point();
 
@@ -465,14 +465,14 @@ mod tests {
         sign_receiving_key: bool,
     ) -> (PublicKey, PublicKey, PublicKey, Box<[VerifiedKeyFrag]>) {
         let delegating_sk = SecretKey::random();
-        let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let signing_sk = SecretKey::random();
         let signer = Signer::new(&signing_sk);
-        let verifying_pk = PublicKey::from_secret_key(&signing_sk);
+        let verifying_pk = signing_sk.public_key();
 
         let receiving_sk = SecretKey::random();
-        let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
+        let receiving_pk = receiving_sk.public_key();
 
         let base = KeyFragBase::new(&delegating_sk, &receiving_pk, &signer, 2);
         let vkfrags = [

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -19,14 +19,14 @@
 //!
 //! // Key Generation (on Alice's side)
 //! let alice_sk = SecretKey::random();
-//! let alice_pk = PublicKey::from_secret_key(&alice_sk);
+//! let alice_pk = alice_sk.public_key();
 //! let signing_sk = SecretKey::random();
 //! let signer = Signer::new(&signing_sk);
-//! let verifying_pk = PublicKey::from_secret_key(&signing_sk);
+//! let verifying_pk = signing_sk.public_key();
 //!
 //! // Key Generation (on Bob's side)
 //! let bob_sk = SecretKey::random();
-//! let bob_pk = PublicKey::from_secret_key(&bob_sk);
+//! let bob_pk = bob_sk.public_key();
 //!
 //! // Now let's encrypt data with Alice's public key.
 //! // Invocation of `encrypt()` returns both the ciphertext and a capsule.

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -143,8 +143,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::{
-        CapsuleFrag, DeserializableFromArray, KeyFrag, PublicKey, SecretKey, SerializableToArray,
-        Signer, VerifiedCapsuleFrag,
+        CapsuleFrag, DeserializableFromArray, KeyFrag, SecretKey, SerializableToArray, Signer,
+        VerifiedCapsuleFrag,
     };
 
     use super::{decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt};
@@ -166,15 +166,15 @@ mod tests {
 
         // Key Generation (Alice)
         let delegating_sk = SecretKey::random();
-        let delegating_pk = PublicKey::from_secret_key(&delegating_sk);
+        let delegating_pk = delegating_sk.public_key();
 
         let signing_sk = SecretKey::random();
         let signer = Signer::new(&signing_sk);
-        let verifying_pk = PublicKey::from_secret_key(&signing_sk);
+        let verifying_pk = signing_sk.public_key();
 
         // Key Generation (Bob)
         let receiving_sk = SecretKey::random();
-        let receiving_pk = PublicKey::from_secret_key(&receiving_sk);
+        let receiving_pk = receiving_sk.public_key();
 
         // Encryption by an unnamed data source
         let plaintext = b"peace at dawn";


### PR DESCRIPTION
Paired with https://github.com/nucypher/pyUmbral/pull/271

See the rationale there. Briefly, this is a more used way, and it coincides with [RustCrypto API](https://docs.rs/elliptic-curve/0.10.1/elliptic_curve/struct.SecretKey.html#method.public_key)