### PR TITLE
Make sure secret data is zeroized on drop and not copied around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `SecretKey` and `SecretKeyFactory` no longer implement `SerializableToArray`, but implement `SerializableToSecretArray` instead. Correspondingly, in the bindings these objects implement `to_secret_bytes()` instead of `__bytes__()` (for Python), and `toSecretBytes()` instead of `toBytes()` (for WASM). ([#53])
+- `SecretKey`, `SecretKeyFactory` and `Signer` do not implement `PartialEq` anymore. Corresponding methods in the bindings were removed as well. ([#53])
+- Bumped `k256` to `0.9` and `ecdsa` to `0.12.2`. ([#53])
+
+
 ### Added
 
 - Added separate entry points for Webpack and Node.JS in the WASM bindings, and added examples for both of these scenarios ([#60])
+- `SecretBox` struct, a wrapper making operations with secret data explicit and ensuring zeroization on drop ([#53])
 
 
 ### Fixed
 
 - Turned off `wasm-bindgen` feature of `getrandom` crate ([#56])
+- Multiple internal changes for safe secret data handling using `SecretBox` ([#53])
 
 
+[#53]: https://github.com/nucypher/rust-umbral/pull/53
 [#56]: https://github.com/nucypher/rust-umbral/pull/56
 [#60]: https://github.com/nucypher/rust-umbral/pull/60
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -30,9 +30,11 @@ API reference
 
         Returns a public key corresponding to this secret key.
 
-    .. py:method:: __bytes__() -> bytes
+    .. py:method:: to_secret_bytes() -> bytes
 
         Serializes the object into a bytestring.
+
+        Made into an explicit method instead of `__bytes__` to avoid unintentional exposure of the secret data.
 
     .. py:staticmethod:: from_bytes(data: bytes) -> SecretKey
 
@@ -54,9 +56,11 @@ API reference
 
         Generates a new :py:class:`SecretKey` using ``label`` as a seed.
 
-    .. py:method:: __bytes__() -> bytes
+    .. py:method:: to_secret_bytes() -> bytes
 
         Serializes the object into a bytestring.
+
+        Made into an explicit method instead of `__bytes__` to avoid unintentional exposure of the secret data.
 
     .. py:staticmethod:: from_bytes(data: bytes) -> SecretKey
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -121,6 +121,10 @@ impl SecretKey {
         }
     }
 
+    pub fn to_secret_bytes(&self) -> PyResult<PyObject> {
+        to_secret_bytes(self)
+    }
+
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
@@ -134,10 +138,6 @@ impl SecretKey {
 
 #[pyproto]
 impl PyObjectProtocol for SecretKey {
-    fn __bytes__(&self) -> PyResult<PyObject> {
-        to_secret_bytes(self)
-    }
-
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }
@@ -178,6 +178,10 @@ impl SecretKeyFactory {
             .map_err(|err| PyValueError::new_err(format!("{}", err)))
     }
 
+    pub fn to_secret_bytes(&self) -> PyResult<PyObject> {
+        to_secret_bytes(self)
+    }
+
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> PyResult<Self> {
         from_bytes(data)
@@ -191,10 +195,6 @@ impl SecretKeyFactory {
 
 #[pyproto]
 impl PyObjectProtocol for SecretKeyFactory {
-    fn __bytes__(&self) -> PyResult<PyObject> {
-        to_secret_bytes(self)
-    }
-
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -10,6 +10,9 @@ class SecretKey:
     def public_key(self) -> PublicKey:
         ...
 
+    def to_secret_bytes(self) -> bytes:
+        ...
+
     @staticmethod
     def from_bytes() -> SecretKey:
         ...
@@ -26,6 +29,9 @@ class SecretKeyFactory:
         ...
 
     def secret_key_by_label(self, label: bytes) -> SecretKey:
+        ...
+
+    def to_secret_bytes(self) -> bytes:
         ...
 
     @staticmethod

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use js_sys::Error;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
-use umbral_pre::{DeserializableFromArray, SerializableToArray};
+use umbral_pre::{DeserializableFromArray, SerializableToArray, SerializableToSecretArray};
 
 fn map_js_err<T: fmt::Display>(err: T) -> JsValue {
     Error::new(&format!("{}", err)).into()
@@ -40,7 +40,11 @@ impl SecretKey {
 
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
-        self.0.to_array().to_vec().into_boxed_slice()
+        self.0
+            .to_secret_array()
+            .as_secret()
+            .to_vec()
+            .into_boxed_slice()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
@@ -54,10 +58,6 @@ impl SecretKey {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         format!("{}", self.0)
-    }
-
-    pub fn equals(&self, other: &SecretKey) -> bool {
-        self.0 == other.0
     }
 }
 
@@ -81,7 +81,11 @@ impl SecretKeyFactory {
 
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
-        self.0.to_array().to_vec().into_boxed_slice()
+        self.0
+            .to_secret_array()
+            .as_secret()
+            .to_vec()
+            .into_boxed_slice()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
@@ -95,10 +99,6 @@ impl SecretKeyFactory {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         format!("{}", self.0)
-    }
-
-    pub fn equals(&self, other: &SecretKeyFactory) -> bool {
-        self.0 == other.0
     }
 }
 
@@ -153,10 +153,6 @@ impl Signer {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         format!("{}", self.0)
-    }
-
-    pub fn equals(&self, other: &Signer) -> bool {
-        self.0 == other.0
     }
 }
 

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -38,8 +38,8 @@ impl SecretKey {
         PublicKey(self.0.public_key())
     }
 
-    #[wasm_bindgen(js_name = toBytes)]
-    pub fn to_bytes(&self) -> Box<[u8]> {
+    #[wasm_bindgen(js_name = toSecretBytes)]
+    pub fn to_secret_bytes(&self) -> Box<[u8]> {
         self.0
             .to_secret_array()
             .as_secret()
@@ -79,8 +79,8 @@ impl SecretKeyFactory {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen(js_name = toBytes)]
-    pub fn to_bytes(&self) -> Box<[u8]> {
+    #[wasm_bindgen(js_name = toSecretBytes)]
+    pub fn to_secret_bytes(&self) -> Box<[u8]> {
         self.0
             .to_secret_array()
             .as_secret()

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -28,6 +28,7 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 subtle = { version = "2.4", default-features = false }
+zeroize = "1.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithmetic"] }
+k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithmetic", "zeroize"] }
 sha2 = "0.9"
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = "0.11"
@@ -18,11 +18,11 @@ hex = "0.4"
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
-elliptic-curve = "0.10"
+elliptic-curve = { version = "0.10", features = ["zeroize"] }
 digest = "0.9"
 generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
-ecdsa = "0.12"
+ecdsa = { version = "0.12", features = ["zeroize"] }
 signature = "1.3"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.10", features = ["zeroize"] }
 digest = "0.9"
 generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
-ecdsa = { version = "0.12", features = ["zeroize"] }
+ecdsa = { version = "0.12.2", features = ["zeroize"] }
 signature = "1.3"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.8", default-features = false, features = ["ecdsa", "arithmetic"] }
+k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithmetic"] }
 sha2 = "0.9"
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = "0.11"
@@ -18,11 +18,11 @@ hex = "0.4"
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
-elliptic-curve = "0.9"
+elliptic-curve = "0.10"
 digest = "0.9"
 generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
-ecdsa = "0.11"
+ecdsa = "0.12"
 signature = "1.3"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -147,7 +147,7 @@ impl Capsule {
 
     /// Derive the same symmetric key
     pub(crate) fn open_original(&self, delegating_sk: &SecretKey) -> CurvePoint {
-        &(&self.point_e + &self.point_v) * &delegating_sk.to_secret_scalar()
+        &(&self.point_e + &self.point_v) * delegating_sk.to_secret_scalar().as_secret()
     }
 
     #[allow(clippy::many_single_char_names)]
@@ -168,7 +168,7 @@ impl Capsule {
         }
 
         let pub_key = receiving_sk.public_key().to_point();
-        let dh_point = &precursor * &receiving_sk.to_secret_scalar();
+        let dh_point = &precursor * receiving_sk.to_secret_scalar().as_secret();
 
         // Combination of CFrags via Shamir's Secret Sharing reconstruction
         let mut lc = Vec::<CurveScalar>::with_capacity(cfrags.len());

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -7,10 +7,9 @@ use core::ops::{Add, Mul, Sub};
 
 use digest::Digest;
 use ecdsa::hazmat::FromDigest;
-use elliptic_curve::ff::PrimeField;
+use elliptic_curve::group::ff::PrimeField;
 use elliptic_curve::sec1::{CompressedPointSize, EncodedPoint, FromEncodedPoint, ToEncodedPoint};
-use elliptic_curve::NonZeroScalar;
-use elliptic_curve::{AffinePoint, Curve, ProjectiveArithmetic, Scalar};
+use elliptic_curve::{AffinePoint, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};
 use generic_array::GenericArray;
 use k256::Secp256k1;
 use rand_core::OsRng;
@@ -79,7 +78,7 @@ impl Default for CurveScalar {
 impl RepresentableAsArray for CurveScalar {
     // Currently it's the only size available.
     // A separate scalar size may appear in later versions of `elliptic_curve`.
-    type Size = <CurveType as Curve>::FieldSize;
+    type Size = FieldSize<CurveType>;
 }
 
 impl SerializableToArray for CurveScalar {

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -155,6 +155,20 @@ impl CurvePoint {
     }
 }
 
+impl Default for CurvePoint {
+    fn default() -> Self {
+        CurvePoint::identity()
+    }
+}
+
+impl DefaultIsZeroes for CurvePoint {}
+
+impl CanBeZeroizedOnDrop for CurvePoint {
+    fn ensure_zeroized_on_drop(&mut self) {
+        self.zeroize()
+    }
+}
+
 impl Add<&CurveScalar> for &CurveScalar {
     type Output = CurveScalar;
 

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -14,7 +14,9 @@ use generic_array::GenericArray;
 use k256::Secp256k1;
 use rand_core::OsRng;
 use subtle::CtOption;
+use zeroize::{DefaultIsZeroes, Zeroize};
 
+use crate::secret_box::CanBeZeroizedOnDrop;
 use crate::traits::{
     ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
     SerializableToArray,
@@ -24,6 +26,12 @@ pub(crate) type CurveType = Secp256k1;
 
 type BackendScalar = Scalar<CurveType>;
 pub(crate) type BackendNonZeroScalar = NonZeroScalar<CurveType>;
+
+impl CanBeZeroizedOnDrop for BackendNonZeroScalar {
+    fn ensure_zeroized_on_drop(&mut self) {
+        self.zeroize()
+    }
+}
 
 // We have to define newtypes for scalar and point here because the compiler
 // is not currently smart enough to resolve `BackendScalar` and `BackendPoint`
@@ -72,6 +80,14 @@ impl CurveScalar {
 impl Default for CurveScalar {
     fn default() -> Self {
         Self(BackendScalar::default())
+    }
+}
+
+impl DefaultIsZeroes for CurveScalar {}
+
+impl CanBeZeroizedOnDrop for CurveScalar {
+    fn ensure_zeroized_on_drop(&mut self) {
+        self.zeroize()
     }
 }
 

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -5,6 +5,7 @@ use sha2::Sha256;
 use typenum::U1;
 
 use crate::curve::{CurvePoint, CurveScalar};
+use crate::secret_box::{CanBeZeroizedOnDrop, SecretBox};
 use crate::traits::SerializableToArray;
 
 /// Hashes arbitrary data with the given domain separation tag
@@ -74,6 +75,14 @@ impl Hash {
         Self(self.0.chain(bytes.as_ref()))
     }
 
+    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + CanBeZeroizedOnDrop>(
+        self,
+        bytes: &SecretBox<T>,
+    ) -> Self {
+        // Assuming here that the bytes are not saved in `BackendDigest`.
+        Self(self.0.chain(bytes.as_secret()))
+    }
+
     pub fn digest(self) -> BackendDigest {
         self.0
     }
@@ -88,6 +97,13 @@ impl ScalarDigest {
 
     pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
         Self(self.0.chain_bytes(bytes))
+    }
+
+    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + CanBeZeroizedOnDrop>(
+        self,
+        bytes: &SecretBox<T>,
+    ) -> Self {
+        Self(self.0.chain_secret_bytes(bytes))
     }
 
     pub fn chain_point(self, point: &CurvePoint) -> Self {

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -423,7 +423,7 @@ impl KeyFragBase {
 
         // Coefficients of the generating polynomial
         // `invert()` is guaranteed not to panic because `d` is nonzero.
-        let coefficient0 = &delegating_sk.to_secret_scalar() * &(d.invert().unwrap());
+        let coefficient0 = delegating_sk.to_secret_scalar().as_secret() * &(d.invert().unwrap());
 
         let mut coefficients = Vec::<CurveScalar>::with_capacity(threshold);
         coefficients.push(coefficient0);

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -85,7 +85,8 @@ impl SecretKey {
 
     pub(crate) fn from_scalar(scalar: &CurveScalar) -> Option<Self> {
         let nz_scalar = BackendNonZeroScalar::new(scalar.to_backend_scalar())?;
-        Some(Self(BackendSecretKey::<CurveType>::new(nz_scalar)))
+        let backend_sk: BackendSecretKey<CurveType> = nz_scalar.into();
+        Some(Self(backend_sk))
     }
 
     /// Returns a reference to the underlying scalar of the secret key.
@@ -96,7 +97,7 @@ impl SecretKey {
         // But we use this secret scalar to multiply not only points, but other scalars too.
         // So there's no point in hiding the actual value here as long as
         // it is going to be effectively dereferenced in other places.
-        CurveScalar::from_backend_scalar(&*self.0.secret_scalar())
+        CurveScalar::from_backend_scalar(&*self.0.to_secret_scalar())
     }
 
     /// Signs a message using the default RNG.

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -124,6 +124,7 @@ pub use keys::{PublicKey, SecretKey, SecretKeyFactory, SecretKeyFactoryError, Si
 pub use pre::{
     decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt, ReencryptionError,
 };
+pub use secret_box::{CanBeZeroizedOnDrop, SecretBox};
 pub use traits::{
     ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray, SerializableToSecretArray, SizeMismatchError,

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -113,6 +113,7 @@ mod key_frag;
 mod keys;
 mod params;
 mod pre;
+mod secret_box;
 mod traits;
 
 pub use capsule::{Capsule, OpenReencryptedError};
@@ -125,5 +126,5 @@ pub use pre::{
 };
 pub use traits::{
     ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
-    RepresentableAsArray, SerializableToArray, SizeMismatchError,
+    RepresentableAsArray, SerializableToArray, SerializableToSecretArray, SizeMismatchError,
 };

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -38,9 +38,8 @@ pub fn encrypt(
     plaintext: &[u8],
 ) -> Result<(Capsule, Box<[u8]>), EncryptionError> {
     let (capsule, key_seed) = Capsule::from_public_key(delegating_pk);
-    let dem = DEM::new(&key_seed.to_array());
-    let capsule_bytes = capsule.to_array();
-    dem.encrypt(plaintext, &capsule_bytes)
+    let dem = DEM::new(&key_seed);
+    dem.encrypt(plaintext, &capsule.to_array())
         .map(|ciphertext| (capsule, ciphertext))
 }
 
@@ -51,7 +50,7 @@ pub fn decrypt_original(
     ciphertext: impl AsRef<[u8]>,
 ) -> Result<Box<[u8]>, DecryptionError> {
     let key_seed = capsule.open_original(delegating_sk);
-    let dem = DEM::new(&key_seed.to_array());
+    let dem = DEM::new(&key_seed);
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
@@ -132,7 +131,7 @@ pub fn decrypt_reencrypted(
     let key_seed = capsule
         .open_reencrypted(receiving_sk, delegating_pk, &cfrags)
         .map_err(ReencryptionError::OnOpen)?;
-    let dem = DEM::new(&key_seed.to_array());
+    let dem = DEM::new(&key_seed);
     dem.decrypt(&ciphertext, &capsule.to_array())
         .map_err(ReencryptionError::OnDecryption)
 }

--- a/umbral-pre/src/secret_box.rs
+++ b/umbral-pre/src/secret_box.rs
@@ -61,7 +61,7 @@ where
 /// Makes the usage of secret data explicit and easy to track,
 /// prevents the secret data from being put on stack,
 /// and zeroizes the contents on drop.
-#[derive(Clone)]
+#[derive(Clone)] // No Debug derivation, to avoid exposing the secret data accidentally.
 pub struct SecretBox<T>(Box<T>)
 where
     T: CanBeZeroizedOnDrop + Clone;
@@ -76,6 +76,10 @@ where
 
     pub fn as_secret(&self) -> &T {
         self.0.as_ref()
+    }
+
+    pub fn as_mut_secret(&mut self) -> &mut T {
+        self.0.as_mut()
     }
 }
 

--- a/umbral-pre/src/secret_box.rs
+++ b/umbral-pre/src/secret_box.rs
@@ -1,0 +1,89 @@
+/*
+This module implements a similar API to what the crate `secrecy` provides.
+So, why our own implementation?
+
+First `secrecy::Secret<T>` does not put its contents in a `Box`.
+Using `Box` is a general recommendation of working with secret data,
+because it prevents the compiler from putting it on stack, thus avoiding possible copies on borrow.
+
+Now, one could use `secrecy::Secret<Box<T>>`.
+The problem here is that `secrecy::Secret` requires its type parameter to implement `Zeroize`.
+This means that for a foreign type `F` (even if it does implement `Zeroize`)
+we need to define `impl Zeroize for Box<F>`.
+But the compiler does not allow impls of foreign traits on foreign types.
+This means that we also need to wrap `F` in a local type, impl `Zeroize` for the wrapper,
+and then for the box of the wrapper.
+This is too much boilerplate.
+
+Additionally, `secrecy::Secret<Box<T>>` means that after each `expose_secret()`
+we will need to deal with opening the `Box` as well.
+It's an inconvenience, albeit a minor one.
+
+The situation may improve in the future, and `secrecy` will actually become usable.
+See https://github.com/iqlusioninc/crates/issues/757
+*/
+
+use alloc::boxed::Box;
+
+use generic_array::{ArrayLength, GenericArray};
+use zeroize::Zeroize;
+
+/// This is a helper trait for [`SecretBox`], asserting that the type implementing it
+/// can either be zeroized (in which case [`ensure_zeroized_on_drop`] is implemented accordingly),
+/// or is zeroized on drop (in which case [`ensure_zeroized_on_drop`] does nothing).
+/// In other words, with this trait we are sure that one way or the other,
+/// on drop of [`SecretBox`] the contents are zeroized.
+///
+/// Ideally these should be two traits, but without trait specialization feature
+/// we cannot have two `Drop` implementations depending on which trait the type has.
+///
+/// Additionally, it allows us to implement [`zeroize::Zeroize`]-like behavior
+/// for foreign types for which the original `Zeroize`
+/// isn't implemented (for example, [`generic_array::GenericArray`]).
+pub trait CanBeZeroizedOnDrop {
+    /// This method will be called on drop.
+    /// The implementor should zeroize the secret parts of the value if it does not do it itself,
+    /// or do nothing otherwise.
+    fn ensure_zeroized_on_drop(&mut self);
+}
+
+impl<T, N> CanBeZeroizedOnDrop for GenericArray<T, N>
+where
+    N: ArrayLength<T>,
+    T: Zeroize,
+{
+    fn ensure_zeroized_on_drop(&mut self) {
+        self.as_mut_slice().iter_mut().zeroize()
+    }
+}
+
+/// A container for secret data.
+/// Makes the usage of secret data explicit and easy to track,
+/// prevents the secret data from being put on stack,
+/// and zeroizes the contents on drop.
+#[derive(Clone)]
+pub struct SecretBox<T>(Box<T>)
+where
+    T: CanBeZeroizedOnDrop + Clone;
+
+impl<T> SecretBox<T>
+where
+    T: CanBeZeroizedOnDrop + Clone,
+{
+    pub(crate) fn new(val: T) -> Self {
+        Self(Box::new(val))
+    }
+
+    pub fn as_secret(&self) -> &T {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Drop for SecretBox<T>
+where
+    T: CanBeZeroizedOnDrop + Clone,
+{
+    fn drop(&mut self) {
+        self.0.ensure_zeroized_on_drop()
+    }
+}

--- a/umbral-pre/src/secret_box.rs
+++ b/umbral-pre/src/secret_box.rs
@@ -29,8 +29,12 @@ use generic_array::{ArrayLength, GenericArray};
 use zeroize::Zeroize;
 
 /// This is a helper trait for [`SecretBox`], asserting that the type implementing it
-/// can either be zeroized (in which case [`ensure_zeroized_on_drop`] is implemented accordingly),
-/// or is zeroized on drop (in which case [`ensure_zeroized_on_drop`] does nothing).
+/// can either be zeroized
+/// (in which case [`ensure_zeroized_on_drop`](`CanBeZeroizedOnDrop::ensure_zeroized_on_drop`)
+/// is implemented accordingly),
+/// or is zeroized on drop
+/// (in which case [`ensure_zeroized_on_drop`](`CanBeZeroizedOnDrop::ensure_zeroized_on_drop`)
+/// does nothing).
 /// In other words, with this trait we are sure that one way or the other,
 /// on drop of [`SecretBox`] the contents are zeroized.
 ///
@@ -74,10 +78,12 @@ where
         Self(Box::new(val))
     }
 
+    /// Returns an immutable reference to the secret data.
     pub fn as_secret(&self) -> &T {
         self.0.as_ref()
     }
 
+    /// Returns a mutable reference to the secret data.
     pub fn as_mut_secret(&mut self) -> &mut T {
         self.0.as_mut()
     }

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -8,6 +8,8 @@ use generic_array::sequence::Split;
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Diff, Unsigned, U1, U8};
 
+use crate::secret_box::SecretBox;
+
 /// Errors that can happen during deserializing an object from a bytestring of correct length.
 #[derive(Debug, PartialEq)]
 pub struct ConstructionError {
@@ -104,6 +106,13 @@ pub trait RepresentableAsArray: Sized {
 pub trait SerializableToArray: RepresentableAsArray {
     /// Produces a byte array with the object's contents.
     fn to_array(&self) -> GenericArray<u8, Self::Size>;
+}
+
+/// A trait denoting that the object can be serialized to an array of bytes
+/// containing secret data.
+pub trait SerializableToSecretArray: RepresentableAsArray {
+    /// Produces a byte array with the object's contents, wrapped in a secret container.
+    fn to_secret_array(&self) -> SecretBox<GenericArray<u8, Self::Size>>;
 }
 
 /// A trait denoting that the object can be deserialized from an array of bytes


### PR DESCRIPTION
Fixes #8 (to the extent Rust allows, at least)

The main principles of keeping secret data secret in Rust are:
- put it in a `Box` to prevent stack allocation (which may lead to unwanted copies left on stack)
- have a `Drop` implementation that zeroizes secret data

We have secret data belonging to three kinds of foreign types:
- those for which `Zeroize` is defined, but which are not zeroized on drop by default (e.g. RustCrypto `Scalar`)
- those for which `Zeroize` is not defined (e.g. `GenericArray`)
- those for which `Zeroize` is not defined, but which are zeroized on drop (e.g. RustCrypto `SecretKey`). Note that RustCrypto `SigningKey` was not zeroized until recently - it is since `ecdsa` 0.12.2

Plus, of course, our own types, but for them at least we can define traits.

Changes in the PR:
- added the `SecretBox` struct, a wrapper that ensures that its contents follow the principles above
- added the `CanBeZeroizedOnDrop` helper trait, to generalize the behavior of all the kinds of types above
- added the `SerializableToSecretArray` trait returning a `SecretBox<GenericArray>`, as opposed to `SerializableToArray`. It will be used for objects containing secret data.
- scalars in `SecretKey` methods are wrapped in `SecretBox` on exposure
- `PartialEq` implementation removed from `SecretKey`, `SecretKeyFactory`, and `Signer` (kept for tests only)
- `SecretBox` is used for the internals of `SecretKey` and `SecretKeyFactory` (`Signer` gets the benefits automatically by using `SecretKey`)
- propagated changes to bindings (`SerializableToSecretArray` + missing equality for secret objects)
- made serialization explicit for secret objects (`to_secret_bytes()` in Python and `toSecretBytes()` in WASM)
- wrapping secret data passing in `kdf`, `DEM` and `Capsule` internally
- initialized a changelog

For reviewers: 
- am I overengineering it? All this is still not a 100% guarantee that Rust won't expose the secret data accidentally (which is kind of a bummer), and we've been using a Python implementation that left copies of secret data everywhere. 
- should `Signer` consume the secret key and not be cloneable, like the backend `SigningKey` in RustCrypto? What does it achieve?