### PR TITLE
Fix compilation on `thumbv7em-none-eabi` target

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -17,7 +17,7 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  build:
+  build-wasm:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,9 +25,6 @@ jobs:
           - 1.51.0 # MSRV
           - stable
         target:
-          # TODO (#13): there are some build problems with `getrandom` package.
-          # See if they are fixed when `k256` and its dependencies switch to `getrandom=0.2`
-          #- thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v1
@@ -39,6 +36,26 @@ jobs:
           override: true
       #- run: cp ../../Cargo.lock .. # Use same Cargo.lock resolution that's checked in
       - run: cargo build --release --target ${{ matrix.target }}
+
+  build-arm:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      #- run: cp ../../Cargo.lock .. # Use same Cargo.lock resolution that's checked in
+      - run: cargo build --release --target ${{ matrix.target }} --no-default-features
 
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added separate entry points for Webpack and Node.JS in the WASM bindings, and added examples for both of these scenarios ([#60])
 - `SecretBox` struct, a wrapper making operations with secret data explicit and ensuring zeroization on drop ([#53])
+- Feature `default-rng` (enabled by default). When disabled, the library can be compiled on targets not supported by `getrandom` (e.g., ARM), but only the functions taking an explicit RNG as a parameter will be available. ([#55])
 
 
 ### Fixed
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [#53]: https://github.com/nucypher/rust-umbral/pull/53
+[#55]: https://github.com/nucypher/rust-umbral/pull/55
 [#56]: https://github.com/nucypher/rust-umbral/pull/56
 [#60]: https://github.com/nucypher/rust-umbral/pull/60
 

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithmetic", "zeroize"] }
-sha2 = "0.9"
+sha2 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
-hkdf = "0.11"
+hkdf = { version = "0.11", default-features = false }
 hex = { version = "0.4", default-features = false }
 
 # These packages are among the dependencies of the packages above.
@@ -23,7 +23,7 @@ digest = "0.9"
 generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
 ecdsa = { version = "0.12.2", features = ["zeroize"] }
-signature = "1.3"
+signature = { version = "1.3", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -24,14 +24,18 @@ generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
 ecdsa = { version = "0.12.2", features = ["zeroize"] }
 signature = "1.3"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
+getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 subtle = { version = "2.4", default-features = false }
 zeroize = "1.3"
 
 [dev-dependencies]
 criterion = "0.3"
+
+[features]
+default = ["default-rng"]
+default-rng = ["getrandom", "rand_core/getrandom"]
 
 [[bench]]
 name = "bench"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -14,7 +14,7 @@ k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithm
 sha2 = "0.9"
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = "0.11"
-hex = "0.4"
+hex = { version = "0.4", default-features = false }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -12,7 +12,7 @@ use elliptic_curve::sec1::{CompressedPointSize, EncodedPoint, FromEncodedPoint, 
 use elliptic_curve::{AffinePoint, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};
 use generic_array::GenericArray;
 use k256::Secp256k1;
-use rand_core::OsRng;
+use rand_core::{CryptoRng, RngCore};
 use subtle::CtOption;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
@@ -66,8 +66,8 @@ impl CurveScalar {
     }
 
     /// Generates a random non-zero scalar (in nearly constant-time).
-    pub(crate) fn random_nonzero() -> CurveScalar {
-        Self(*BackendNonZeroScalar::random(&mut OsRng))
+    pub(crate) fn random_nonzero(rng: &mut (impl CryptoRng + RngCore)) -> CurveScalar {
+        Self(*BackendNonZeroScalar::random(rng))
     }
 
     pub(crate) fn from_digest(

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -6,8 +6,7 @@ use chacha20poly1305::aead::NewAead;
 use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
 use generic_array::{ArrayLength, GenericArray};
 use hkdf::Hkdf;
-use rand_core::OsRng;
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 use sha2::Sha256;
 use typenum::Unsigned;
 
@@ -96,11 +95,12 @@ impl DEM {
 
     pub fn encrypt(
         &self,
+        rng: &mut (impl CryptoRng + RngCore),
         data: &[u8],
         authenticated_data: &[u8],
     ) -> Result<Box<[u8]>, EncryptionError> {
         let mut nonce = GenericArray::<u8, NonceSize>::default();
-        OsRng.fill_bytes(&mut nonce);
+        rng.fill_bytes(&mut nonce);
         let nonce = XNonce::from_slice(&nonce);
         let payload = Payload {
             msg: data,

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -122,10 +122,14 @@ pub use dem::{DecryptionError, EncryptionError};
 pub use key_frag::{KeyFrag, KeyFragVerificationError, VerifiedKeyFrag};
 pub use keys::{PublicKey, SecretKey, SecretKeyFactory, SecretKeyFactoryError, Signature, Signer};
 pub use pre::{
-    decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt, ReencryptionError,
+    decrypt_original, decrypt_reencrypted, encrypt_with_rng, generate_kfrags_with_rng,
+    reencrypt_with_rng, ReencryptionError,
 };
 pub use secret_box::{CanBeZeroizedOnDrop, SecretBox};
 pub use traits::{
     ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray, SerializableToSecretArray, SizeMismatchError,
 };
+
+#[cfg(feature = "default-rng")]
+pub use pre::{encrypt, generate_kfrags, reencrypt};

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -212,7 +212,14 @@ where
 {
     let bytes = (*obj).to_array();
     let (to_show, _): (GenericArray<u8, U8>, GenericArray<u8, _>) = bytes.split();
-    write!(f, "{}:{}", T::type_name(), hex::encode(to_show))
+    let mut hex_repr = [b'*'; 16]; // exactly 16 bytes long, to fit the encode() result
+    hex::encode_to_slice(to_show, &mut hex_repr).map_err(|_| fmt::Error)?;
+    write!(
+        f,
+        "{}:{}",
+        T::type_name(),
+        String::from_utf8_lossy(&hex_repr)
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #13
Based on top of #53 

Changes:
- added a feature `default-rng` (enabled by default), that enables the use of the system RNG. Without it, `SecretKey::random()`, `SecretKeyFactory::random()`, `encrypt()`, `generate_kfrags()`, and `reencrypt()` are not available; one has to use the `*_with_rng()` options and provide an RNG manually. 
- enabled compilation on an ARM target (`thumbv7em-none-eabi`) in the CI

For reviewers:
- Should the default-rng versions have the "default" names, or the ones with the explicit RNG? That is, `random_with_rng()` and `random()`, or `random()` and `random_with_default_rng()` (or whatever other name; this might be too long). RustCrypto uses explicit RNG everywhere, so the latter variant would be closer to it, but the default RNG functions are the ones used the most, so it is better to keep their names short.
- Should `default-rng` be a feature (like now), or should we have a `no-default-rng` feature instead, to be enabled when compiling for a platform not supported in `getrandom()`?


