### PR TITLE
getrandom: Don't set "wasm-bindgen"

### DIFF
--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -26,7 +26,7 @@ ecdsa = "0.11"
 signature = "1.3"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
-getrandom = { version = "0.2", default-features = false, features = ["wasm-bindgen", "js"] }
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
 subtle = { version = "2.4", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
The only stable features of `getrandom` are:
  - `"std"`
  - `"rdrand"`
  - `"js"`
  - `"custom"`

Setting `"wasm-bindgen"` isn't guaranteed to work going forward (and does nothing currently).

Just to note, your crate is also setting the `"js"` feature. This is basically saying, "every `wasm32-unknown-unknown` user of this crate is either on Node.js or Client-side Web, and has access to JavaScript". This is a very reasonable restriction for your use case (as this project seems to have explicit JavaScript bindings), but we always want dependent library crates to be aware of this.

Signed-off-by: Joe Richey <joerichey@google.com>