### PR TITLE
Add `VerifiedCapsuleFrag::from_verified_bytes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecretBox` struct, a wrapper making operations with secret data explicit and ensuring zeroization on drop ([#53])
 - Feature `default-rng` (enabled by default). When disabled, the library can be compiled on targets not supported by `getrandom` (e.g., ARM), but only the functions taking an explicit RNG as a parameter will be available. ([#55])
 - Added benchmarks for the main usage scenario and a feature `bench-internals` to expose some internals for benchmarking ([#54])
+- Added `VerifiedCapsuleFrag::from_verified_bytes()` ([#63])
 
 
 ### Fixed
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#55]: https://github.com/nucypher/rust-umbral/pull/55
 [#56]: https://github.com/nucypher/rust-umbral/pull/56
 [#60]: https://github.com/nucypher/rust-umbral/pull/60
+[#63]: https://github.com/nucypher/rust-umbral/pull/63
 
 
 ## [0.2.0] - 2021-06-14

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -246,6 +246,14 @@ API reference
 
     A verified capsule fragment, good for decryption.
 
+    .. py:method:: from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag
+
+        Restores a verified capsule frag directly from serialized bytes,
+        skipping :py:meth:`CapsuleFrag.verify` call.
+
+        Intended for internal storage;
+        make sure that the bytes come from a trusted source.
+
     .. py:method:: __bytes__() -> bytes
 
         Serializes the object into a bytestring.

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -670,6 +670,13 @@ impl PyObjectProtocol for VerifiedCapsuleFrag {
 #[pymethods]
 impl VerifiedCapsuleFrag {
     #[staticmethod]
+    pub fn from_verified_bytes(data: &[u8]) -> PyResult<Self> {
+        umbral_pre::VerifiedCapsuleFrag::from_verified_bytes(data)
+            .map(|vcfrag| Self { backend: vcfrag })
+            .map_err(|err| PyValueError::new_err(format!("{}", err)))
+    }
+
+    #[staticmethod]
     pub fn serialized_size() -> usize {
         umbral_pre::VerifiedCapsuleFrag::serialized_size()
     }

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -158,6 +158,9 @@ class CapsuleFrag:
 
 class VerifiedCapsuleFrag:
 
+    def from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag:
+        ...
+
     @staticmethod
     def serialized_size() -> int:
         ...

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -282,6 +282,13 @@ pub struct VerifiedCapsuleFrag(umbral_pre::VerifiedCapsuleFrag);
 
 #[wasm_bindgen]
 impl VerifiedCapsuleFrag {
+    #[wasm_bindgen(js_name = fromVerifiedBytes)]
+    pub fn from_verified_bytes(bytes: &[u8]) -> Result<VerifiedCapsuleFrag, JsValue> {
+        umbral_pre::VerifiedCapsuleFrag::from_verified_bytes(bytes)
+            .map(Self)
+            .map_err(map_js_err)
+    }
+
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.to_array().to_vec().into_boxed_slice()

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -11,8 +11,8 @@ use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
 use crate::traits::{
-    fmt_public, ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
-    SerializableToArray,
+    fmt_public, ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
+    RepresentableAsArray, SerializableToArray,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -310,6 +310,15 @@ impl VerifiedCapsuleFrag {
         VerifiedCapsuleFrag {
             cfrag: CapsuleFrag::reencrypted(rng, capsule, kfrag),
         }
+    }
+
+    /// Restores a verified capsule frag directly from serialized bytes,
+    /// skipping [`CapsuleFrag::verify`] call.
+    ///
+    /// Intended for internal storage;
+    /// make sure that the bytes come from a trusted source.
+    pub fn from_verified_bytes(data: impl AsRef<[u8]>) -> Result<Self, DeserializationError> {
+        CapsuleFrag::from_bytes(data).map(|cfrag| Self { cfrag })
     }
 }
 


### PR DESCRIPTION
Fixes #58

`VerifiedCapsuleFrag::from_verified_bytes()` was added to support caching of capsule frags on the receiver's side (by analogy with the existing `VerifiedKeyFrag::from_verified_bytes()`), when there is no need to re-verify on deserialization.