### PR TITLE
Additional `SecretKeyFactory` constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added benchmarks for the main usage scenario and a feature `bench-internals` to expose some internals for benchmarking. ([#54])
 - Added `VerifiedCapsuleFrag::from_verified_bytes()`. ([#63])
 - Added `SecretKeyFactory::secret_key_factory_by_label()`. ([#64])
+- Added `SecretKeyFactory::from_secure_randomness()` and `seed_size()`. ([#64])
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feature `default-rng` (enabled by default). When disabled, the library can be compiled on targets not supported by `getrandom` (e.g., ARM), but only the functions taking an explicit RNG as a parameter will be available. ([#55])
 - Added benchmarks for the main usage scenario and a feature `bench-internals` to expose some internals for benchmarking. ([#54])
 - Added `VerifiedCapsuleFrag::from_verified_bytes()`. ([#63])
+- Added `SecretKeyFactory::secret_key_factory_by_label()`. ([#64])
 
 
 ### Fixed
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#56]: https://github.com/nucypher/rust-umbral/pull/56
 [#60]: https://github.com/nucypher/rust-umbral/pull/60
 [#63]: https://github.com/nucypher/rust-umbral/pull/63
+[#64]: https://github.com/nucypher/rust-umbral/pull/64
 [#65]: https://github.com/nucypher/rust-umbral/pull/65
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecretKey`, `SecretKeyFactory` and `Signer` do not implement `PartialEq` anymore. Corresponding methods in the bindings were removed as well. ([#53])
 - Bumped `k256` to `0.9` and `ecdsa` to `0.12.2`. ([#53])
 - Bumped `pyo3` to `0.14`. ([#65])
+- Reduced the size of key material in `SecretKeyFactory` from 64 to 32 bytes. ([#64])
 
 
 ### Added

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -52,9 +52,13 @@ API reference
 
         Generates a new random factory.
 
-    .. py:method:: secret_key_by_label(label: bytes) -> SecretKeyFactory
+    .. py:method:: secret_key_by_label(label: bytes) -> SecretKey
 
         Generates a new :py:class:`SecretKey` using ``label`` as a seed.
+
+    .. py:method:: secret_key_factory_by_label(label: bytes) -> SecretKeyFactory
+
+        Generates a new :py:class:`SecretKeyFactory` using ``label`` as a seed.
 
     .. py:method:: to_secret_bytes() -> bytes
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -52,6 +52,18 @@ API reference
 
         Generates a new random factory.
 
+    .. py:staticmethod:: seed_size() -> int
+
+        Returns the seed size required by :py:meth:`~SecretKeyFactory.from_secure_randomness`.
+
+    .. py:staticmethod:: from_secure_randomness(seed: bytes) -> SecretKeyFactory
+
+        Creates a secret key factory using the given random bytes.
+        The length of the bytestring must be the one returned by :py:meth:`~SecretKeyFactory.seed_size`.
+
+        **Warning:** make sure the given seed has been obtained
+        from a cryptographically secure source of randomness!
+
     .. py:method:: secret_key_by_label(label: bytes) -> SecretKey
 
         Generates a new :py:class:`SecretKey` using ``label`` as a seed.

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -178,6 +178,12 @@ impl SecretKeyFactory {
             .map_err(|err| PyValueError::new_err(format!("{}", err)))
     }
 
+    pub fn secret_key_factory_by_label(&self, label: &[u8]) -> Self {
+        Self {
+            backend: self.backend.secret_key_factory_by_label(label),
+        }
+    }
+
     pub fn to_secret_bytes(&self) -> PyResult<PyObject> {
         to_secret_bytes(self)
     }

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -169,6 +169,20 @@ impl SecretKeyFactory {
         }
     }
 
+    #[staticmethod]
+    pub fn seed_size() -> usize {
+        umbral_pre::SecretKeyFactory::seed_size()
+    }
+
+    #[staticmethod]
+    pub fn from_secure_randomness(seed: &[u8]) -> PyResult<SecretKeyFactory> {
+        umbral_pre::SecretKeyFactory::from_secure_randomness(seed)
+            .map(|backend_sk| SecretKeyFactory {
+                backend: backend_sk,
+            })
+            .map_err(|err| PyValueError::new_err(format!("{}", err)))
+    }
+
     pub fn secret_key_by_label(&self, label: &[u8]) -> PyResult<SecretKey> {
         self.backend
             .secret_key_by_label(label)

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -28,6 +28,14 @@ class SecretKeyFactory:
     def random() -> SecretKeyFactory:
         ...
 
+    @staticmethod
+    def seed_size() -> int:
+        ...
+
+    @staticmethod
+    def from_secure_randomness(seed: bytes) -> SecretKeyFactory:
+        ...
+
     def secret_key_by_label(self, label: bytes) -> SecretKey:
         ...
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -31,6 +31,9 @@ class SecretKeyFactory:
     def secret_key_by_label(self, label: bytes) -> SecretKey:
         ...
 
+    def secret_key_factory_by_label(self, label: bytes) -> SecretKeyFactory:
+        ...
+
     def to_secret_bytes(self) -> bytes:
         ...
 

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -79,6 +79,11 @@ impl SecretKeyFactory {
             .map_err(map_js_err)
     }
 
+    #[wasm_bindgen(js_name = secretKeyFactoryByLabel)]
+    pub fn secret_key_factory_by_label(&self, label: &[u8]) -> Self {
+        Self(self.0.secret_key_factory_by_label(label))
+    }
+
     #[wasm_bindgen(js_name = toSecretBytes)]
     pub fn to_secret_bytes(&self) -> Box<[u8]> {
         self.0

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -71,6 +71,18 @@ impl SecretKeyFactory {
         Self(umbral_pre::SecretKeyFactory::random())
     }
 
+    #[wasm_bindgen(js_name = seedSize)]
+    pub fn seed_size() -> usize {
+        umbral_pre::SecretKeyFactory::seed_size()
+    }
+
+    #[wasm_bindgen(js_name = fromSecureRandomness)]
+    pub fn from_secure_randomness(seed: &[u8]) -> Result<SecretKeyFactory, JsValue> {
+        umbral_pre::SecretKeyFactory::from_secure_randomness(seed)
+            .map(Self)
+            .map_err(map_js_err)
+    }
+
     #[wasm_bindgen(js_name = secretKeyByLabel)]
     pub fn secret_key_by_label(&self, label: &[u8]) -> Result<SecretKey, JsValue> {
         self.0

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -266,7 +266,7 @@ impl fmt::Display for SecretKeyFactoryError {
     }
 }
 
-type SecretKeyFactorySeedSize = U64; // the size of the seed material for key derivation
+type SecretKeyFactorySeedSize = U32; // the size of the seed material for key derivation
 type SecretKeyFactoryDerivedSize = U64; // the size of the derived key (before hashing to scalar)
 type SecretKeyFactorySeed = GenericArray<u8, SecretKeyFactorySeedSize>;
 


### PR DESCRIPTION
- Added `SecretKeyFactory::secret_key_factory_by_label()` (fixes #59)
- Added `SecretKeyFactory::from_secure_randomness()` and `seed_size()` (fixes #57)
- Reduced the key material size in `SecretKeyFactory` from 64 to 32 bytes (as discussed with @cygnusv). 
 
Note that the derived key size is still 64 bytes in `secret_key_by_label()` to reduce aliasing when converting the derived bytes into a scalar (with modulo reduction). Since they pass through a hash function, I'm not sure if that's important.

Also, in Discord @cygnusv suggested using `Scalar::from_bytes_reduced()` instead of `from_digest()` to avoid the hashing step in `secret_key_by_label()`. I have the following concerns about it:
- it takes a `FieldBytes` argument, which indicates that it's a semi-internal function - there is no "official" way to create `FieldBytes`. Technically, it is an alias for `GenericArray`, so it can be created, but seems a little fragile.
- `from_bytes_reduced()` just takes a modulus, so if we're passing 32 bytes to it (the current size of `FieldBytes`), it can introduce aliasing.

