### PR TITLE
`serde` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VerifiedCapsuleFrag::from_verified_bytes()`. ([#63])
 - Added `SecretKeyFactory::secret_key_factory_by_label()`. ([#64])
 - Added `SecretKeyFactory::from_secure_randomness()` and `seed_size()`. ([#64])
+- `serde` support for `Capsule`, `CapsuleFrag`, `KeyFrag`, `PublicKey`, and `Signature`. ([#67])
 
 
 ### Fixed
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#63]: https://github.com/nucypher/rust-umbral/pull/63
 [#64]: https://github.com/nucypher/rust-umbral/pull/64
 [#65]: https://github.com/nucypher/rust-umbral/pull/65
+[#67]: https://github.com/nucypher/rust-umbral/pull/67
 
 
 ## [0.2.0] - 2021-06-14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "umbral-pre-wasm",
     "umbral-pre-python",
 ]
+
+# Prevents feature conflicts between [dependencies] and [dev-dependencies]
+# Will be the default in 2021 edition.
+resolver = "2"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -14,7 +14,9 @@ k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithm
 sha2 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = { version = "0.11", default-features = false }
-hex = { version = "0.4", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false }
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
@@ -32,6 +34,8 @@ zeroize = "1.3"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
+serde_json = "1"
+rmp-serde = "0.15"
 
 [features]
 default = ["default-rng"]

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -116,6 +116,7 @@ mod keys;
 mod params;
 mod pre;
 mod secret_box;
+mod serde;
 mod traits;
 
 pub use capsule::{Capsule, OpenReencryptedError};

--- a/umbral-pre/src/serde.rs
+++ b/umbral-pre/src/serde.rs
@@ -1,0 +1,175 @@
+use core::fmt;
+use core::marker::PhantomData;
+
+use serde::{de, Deserializer, Serializer};
+
+use crate::traits::{DeserializableFromArray, HasTypeName, SerializableToArray};
+
+pub(crate) enum Representation {
+    Base64,
+    Hex,
+}
+
+// We cannot have a generic implementation of Serialize over everything
+// that supports SerializableToArray, so we have to use this helper function
+// and define implementations manually.
+pub(crate) fn serde_serialize<T, S>(
+    obj: &T,
+    serializer: S,
+    representation: Representation,
+) -> Result<S::Ok, S::Error>
+where
+    T: SerializableToArray,
+    S: Serializer,
+{
+    if serializer.is_human_readable() {
+        let repr = match representation {
+            Representation::Base64 => base64::encode(obj.to_array().as_ref()),
+            Representation::Hex => hex::encode(obj.to_array().as_ref()),
+        };
+        serializer.serialize_str(&repr)
+    } else {
+        serializer.serialize_bytes(obj.to_array().as_ref())
+    }
+}
+
+struct B64Visitor<T>(PhantomData<T>);
+
+impl<'de, T> de::Visitor<'de> for B64Visitor<T>
+where
+    T: DeserializableFromArray + HasTypeName,
+{
+    type Value = T;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "b64-encoded {} bytes", T::type_name())
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let bytes = base64::decode(v).map_err(de::Error::custom)?;
+        T::from_bytes(&bytes).map_err(de::Error::custom)
+    }
+}
+
+struct HexVisitor<T>(PhantomData<T>);
+
+impl<'de, T> de::Visitor<'de> for HexVisitor<T>
+where
+    T: DeserializableFromArray + HasTypeName,
+{
+    type Value = T;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "hex-encoded {} bytes", T::type_name())
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let bytes = hex::decode(v).map_err(de::Error::custom)?;
+        T::from_bytes(&bytes).map_err(de::Error::custom)
+    }
+}
+
+struct BytesVisitor<T>(PhantomData<T>);
+
+impl<'de, T> de::Visitor<'de> for BytesVisitor<T>
+where
+    T: DeserializableFromArray + HasTypeName,
+{
+    type Value = T;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} bytes", T::type_name())
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        T::from_bytes(v).map_err(de::Error::custom)
+    }
+}
+
+// We cannot have a generic implementation of Deerialize over everything
+// that supports DeserializableFromArray, so we have to use this helper function
+// and define implementations manually.
+pub(crate) fn serde_deserialize<'de, T, D>(
+    deserializer: D,
+    representation: Representation,
+) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializableFromArray + HasTypeName,
+{
+    if deserializer.is_human_readable() {
+        match representation {
+            Representation::Base64 => deserializer.deserialize_str(B64Visitor::<T>(PhantomData)),
+            Representation::Hex => deserializer.deserialize_str(HexVisitor::<T>(PhantomData)),
+        }
+    } else {
+        deserializer.deserialize_bytes(BytesVisitor::<T>(PhantomData))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+
+    use core::fmt;
+
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+    use serde_json;
+
+    use super::Representation;
+    use crate::SerializableToArray;
+
+    /// A helper function that checks that serialization to a human-readable format
+    /// uses b64 encoding, and serialization to a binary format contains plain bytes of the object.
+    pub(crate) fn check_serialization<T>(obj: &T, representation: Representation)
+    where
+        T: SerializableToArray + fmt::Debug + PartialEq + Serialize,
+    {
+        // Check serialization to JSON (human-readable)
+
+        let serialized = serde_json::to_string(obj).unwrap();
+
+        let substr = match representation {
+            Representation::Base64 => base64::encode(obj.to_array().as_ref()),
+            Representation::Hex => hex::encode(obj.to_array().as_ref()),
+        };
+
+        // check that the serialization contains the properly encoded bytestring
+        assert!(serialized.contains(&substr));
+
+        // Check serialization to MessagePack (binary)
+
+        let serialized = rmp_serde::to_vec(obj).unwrap();
+        let bytes = obj.to_array();
+        // check that the serialization contains the bytestring
+        assert!(serialized
+            .windows(bytes.len())
+            .any(move |sub_slice| sub_slice == bytes.as_ref()));
+    }
+
+    pub(crate) fn check_deserialization<T>(obj: &T)
+    where
+        T: SerializableToArray + fmt::Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        // Check serialization to JSON (human-readable)
+
+        let serialized = serde_json::to_string(obj).unwrap();
+        let deserialized: T = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(obj, &deserialized);
+
+        // Check serialization to MessagePack (binary)
+
+        let serialized = rmp_serde::to_vec(obj).unwrap();
+        let deserialized: T = rmp_serde::from_read(&*serialized).unwrap();
+        assert_eq!(obj, &deserialized);
+    }
+}


### PR DESCRIPTION
- adds `Serialize`/`Deserialize` implementations for `PublicKey`, `Signature`, `Capsule`, `KeyFrag`, `CapsuleFrag`
- for human-readable formats, `PublicKey` is serialized as hex, and the rest in base64-encoded form

Note: all the serializations simply use the bytestring produced by `to_array()` for binary formats, and the b64 encoding of it for human-readable formats; this helps preserve compatibility with `pyumbral` (as opposed to implementing `Serialize` for `CurveScalar` and `CurvePoint`, and deriving the rest).

For now, not including any `serde` support for `Verified*` objects - they won't be used as nested fields in any protocol objects, so the existing serialization support is enough. Same for the secret objects (`SecretKey`, `SecretKeyFactory`).

For future: we could expose the binary/b64 mechanic to help serialize ciphertexts too. Either as a wrapper class, or returning a `Ciphertext` object that would implement `serde` traits. Not in this PR.