### PR TITLE
Fix needless borrows

### DIFF
--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -189,7 +189,7 @@ impl Capsule {
 
         let mut e_prime = CurvePoint::identity();
         let mut v_prime = CurvePoint::identity();
-        for (i, cfrag) in (&cfrags).iter().enumerate() {
+        for (i, cfrag) in cfrags.iter().enumerate() {
             // There is a minuscule probability that coefficients for two different frags are equal,
             // in which case we'd rather fail gracefully.
             let lambda_i =

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -193,7 +193,7 @@ impl CapsuleFrag {
         let rk = kfrag.key;
         let e1 = &capsule.point_e * &rk;
         let v1 = &capsule.point_v * &rk;
-        let proof = CapsuleFragProof::from_kfrag_and_cfrag(rng, &capsule, &kfrag, &e1, &v1);
+        let proof = CapsuleFragProof::from_kfrag_and_cfrag(rng, capsule, kfrag, &e1, &v1);
 
         Self {
             point_e1: e1,

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -49,7 +49,7 @@ impl CurveScalar {
         Self(*scalar)
     }
 
-    pub(crate) fn to_backend_scalar(&self) -> BackendScalar {
+    pub(crate) fn to_backend_scalar(self) -> BackendScalar {
         self.0
     }
 
@@ -136,7 +136,7 @@ impl CurvePoint {
         Self(BackendPoint::identity())
     }
 
-    pub(crate) fn to_affine_point(&self) -> BackendPointAffine {
+    pub(crate) fn to_affine_point(self) -> BackendPointAffine {
         self.0.to_affine()
     }
 
@@ -148,7 +148,7 @@ impl CurvePoint {
         cp_opt.map(Self)
     }
 
-    fn to_compressed_array(&self) -> GenericArray<u8, CompressedPointSize<CurveType>> {
+    fn to_compressed_array(self) -> GenericArray<u8, CompressedPointSize<CurveType>> {
         *GenericArray::<u8, CompressedPointSize<CurveType>>::from_slice(
             self.0.to_affine().to_encoded_point(true).as_bytes(),
         )

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -66,7 +66,7 @@ pub(crate) fn kdf<T: AsRef<[u8]> + Clone + CanBeZeroizedOnDrop, S: ArrayLength<u
     let def_info = info.unwrap_or(&[]);
 
     // We can only get an error here if `S` is too large, and it's known at compile-time.
-    hk.expand(&def_info, okm.as_mut_secret()).unwrap();
+    hk.expand(def_info, okm.as_mut_secret()).unwrap();
 
     okm
 }

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -113,7 +113,7 @@ impl ScalarDigest {
     pub fn chain_points(self, points: &[CurvePoint]) -> Self {
         let mut digest = self;
         for point in points {
-            digest = digest.chain_point(&point);
+            digest = digest.chain_point(point);
         }
         digest
     }

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -125,7 +125,7 @@ impl KeyFragProof {
         let signature_for_receiver = base.signer.sign_with_rng(
             rng,
             kfrag_signature_message(
-                &kfrag_id,
+                kfrag_id,
                 &commitment,
                 &base.precursor,
                 maybe_delegating_pk,
@@ -137,7 +137,7 @@ impl KeyFragProof {
         let signature_for_proxy = base.signer.sign_with_rng(
             rng,
             kfrag_signature_message(
-                &kfrag_id,
+                kfrag_id,
                 &commitment,
                 &base.precursor,
                 none_unless(maybe_delegating_pk, sign_delegating_key),
@@ -265,7 +265,7 @@ impl KeyFrag {
 
         let proof = KeyFragProof::from_base(
             rng,
-            &base,
+            base,
             &kfrag_id,
             &rk,
             sign_delegating_key,

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -51,7 +51,7 @@ impl Signature {
     /// Verifies that the given message was signed with the secret counterpart of the given key.
     /// The message is hashed internally.
     pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
-        verifying_key.verify_digest(digest_for_signing(message), &self)
+        verifying_key.verify_digest(digest_for_signing(message), self)
     }
 }
 
@@ -204,7 +204,7 @@ pub struct PublicKey(BackendPublicKey<CurveType>);
 
 impl PublicKey {
     /// Returns the underlying curve point of the public key.
-    pub(crate) fn to_point(&self) -> CurvePoint {
+    pub(crate) fn to_point(self) -> CurvePoint {
         CurvePoint::from_backend_point(&self.0.to_projective())
     }
 
@@ -231,7 +231,7 @@ impl SerializableToArray for PublicKey {
 
 impl DeserializableFromArray for PublicKey {
     fn from_array(arr: &GenericArray<u8, Self::Size>) -> Result<Self, ConstructionError> {
-        let cp = CurvePoint::from_array(&arr)?;
+        let cp = CurvePoint::from_array(arr)?;
         BackendPublicKey::<CurveType>::from_affine(cp.to_affine_point())
             .map(Self)
             .map_err(|_| ConstructionError::new("PublicKey", "Internal backend error"))


### PR DESCRIPTION
A new lint in `clippy` provides warnings about needless borrows. 