### PR TITLE
Rename "num_kfrags" to "shares"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `k256` to `0.9` and `ecdsa` to `0.12.2`. ([#53])
 - Bumped `pyo3` to `0.14`. ([#65])
 - Reduced the size of key material in `SecretKeyFactory` from 64 to 32 bytes. ([#64])
+- Renamed `num_kfrags` to `shares` in `genereate_kfrags` ([#69])
 
 
 ### Added
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#64]: https://github.com/nucypher/rust-umbral/pull/64
 [#65]: https://github.com/nucypher/rust-umbral/pull/65
 [#67]: https://github.com/nucypher/rust-umbral/pull/67
+[#69]: https://github.com/nucypher/rust-umbral/pull/69
 
 
 ## [0.2.0] - 2021-06-14

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -168,9 +168,9 @@ API reference
 
     Decrypts ``ciphertext`` with the secret key of the delegator.
 
-.. py:function:: generate_kfrags(delegating_sk: SecretKey, receiving_pk: PublicKey, signer: Signer, threshold: int, num_kfrags: int, sign_delegating_key: bool, sign_receiving_key: bool) -> List[VerifiedKeyFrag]
+.. py:function:: generate_kfrags(delegating_sk: SecretKey, receiving_pk: PublicKey, signer: Signer, threshold: int, shares: int, sign_delegating_key: bool, sign_receiving_key: bool) -> List[VerifiedKeyFrag]
 
-    Generates ``num_kfrags`` key fragments that can be used to reencrypt the capsule for the holder of the secret key corresponding to ``receiving_pk``. ``threshold`` fragments will be enough for decryption.
+    Generates ``shares`` key fragments that can be used to reencrypt the capsule for the holder of the secret key corresponding to ``receiving_pk``. ``threshold`` fragments will be enough for decryption.
 
     If ``sign_delegating_key`` or ``sign_receiving_key`` are ``True``, include these keys in the signature allowing proxies to verify the fragments were created with a given key or for a given key, respectively.
 

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -565,7 +565,7 @@ pub fn generate_kfrags(
     receiving_pk: &PublicKey,
     signer: &Signer,
     threshold: usize,
-    num_kfrags: usize,
+    shares: usize,
     sign_delegating_key: bool,
     sign_receiving_key: bool,
 ) -> Vec<VerifiedKeyFrag> {
@@ -574,7 +574,7 @@ pub fn generate_kfrags(
         &receiving_pk.backend,
         &signer.backend,
         threshold,
-        num_kfrags,
+        shares,
         sign_delegating_key,
         sign_receiving_key,
     );

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -140,7 +140,7 @@ def generate_kfrags(
         receiving_pk: PublicKey,
         signer: SecretKey,
         threshold: int,
-        num_kfrags: int,
+        shares: int,
         sign_delegating_key: bool,
         sign_receiving_key: bool,
         ) -> List[VerifiedKeyFrag]:

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -523,7 +523,7 @@ pub fn generate_kfrags(
     receiving_pk: &PublicKey,
     signer: &Signer,
     threshold: usize,
-    num_kfrags: usize,
+    shares: usize,
     sign_delegating_key: bool,
     sign_receiving_key: bool,
 ) -> Vec<JsValue> {
@@ -532,7 +532,7 @@ pub fn generate_kfrags(
         &receiving_pk.0,
         &signer.0,
         threshold,
-        num_kfrags,
+        shares,
         sign_delegating_key,
         sign_receiving_key,
     );

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -69,7 +69,7 @@ pub fn decrypt_original(
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
-/// Creates `num_kfrags` fragments of `delegating_sk`,
+/// Creates `shares` fragments of `delegating_sk`,
 /// which will be possible to reencrypt to allow the creator of `receiving_pk`
 /// decrypt the ciphertext encrypted with `delegating_sk`.
 ///
@@ -84,7 +84,7 @@ pub fn decrypt_original(
 /// corresponds to given delegating or receiving public keys
 /// by supplying them to [`KeyFrag::verify()`](`crate::KeyFrag::verify`).
 ///
-/// Returns a boxed slice of `num_kfrags` KeyFrags
+/// Returns a boxed slice of `shares` KeyFrags
 #[allow(clippy::too_many_arguments)]
 pub fn generate_kfrags_with_rng(
     rng: &mut (impl CryptoRng + RngCore),
@@ -92,14 +92,14 @@ pub fn generate_kfrags_with_rng(
     receiving_pk: &PublicKey,
     signer: &Signer,
     threshold: usize,
-    num_kfrags: usize,
+    shares: usize,
     sign_delegating_key: bool,
     sign_receiving_key: bool,
 ) -> Box<[VerifiedKeyFrag]> {
     let base = KeyFragBase::new(rng, delegating_sk, receiving_pk, signer, threshold);
 
     let mut result = Vec::<VerifiedKeyFrag>::new();
-    for _ in 0..num_kfrags {
+    for _ in 0..shares {
         result.push(VerifiedKeyFrag::from_base(
             rng,
             &base,
@@ -119,7 +119,7 @@ pub fn generate_kfrags(
     receiving_pk: &PublicKey,
     signer: &Signer,
     threshold: usize,
-    num_kfrags: usize,
+    shares: usize,
     sign_delegating_key: bool,
     sign_receiving_key: bool,
 ) -> Box<[VerifiedKeyFrag]> {
@@ -129,7 +129,7 @@ pub fn generate_kfrags(
         receiving_pk,
         signer,
         threshold,
-        num_kfrags,
+        shares,
         sign_delegating_key,
         sign_receiving_key,
     )


### PR DESCRIPTION
Following the standard terminology in `nucypher`