### PR TITLE
Naming fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced the size of key material in `SecretKeyFactory` from 64 to 32 bytes. ([#64])
 - Renamed `num_kfrags` to `shares` in `genereate_kfrags`. ([#69])
 - Renamed `SecretKeyFactory::secret_key_by_label()`/`secret_factory_by_label()` to `make_key()`/`make_factory()`. ([#71])
+- Renamed remaining instances of `verifying_key` parameter to `verifying_pk`. ([#71])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `k256` to `0.9` and `ecdsa` to `0.12.2`. ([#53])
 - Bumped `pyo3` to `0.14`. ([#65])
 - Reduced the size of key material in `SecretKeyFactory` from 64 to 32 bytes. ([#64])
-- Renamed `num_kfrags` to `shares` in `genereate_kfrags` ([#69])
+- Renamed `num_kfrags` to `shares` in `genereate_kfrags`. ([#69])
+- Renamed `SecretKeyFactory::secret_key_by_label()`/`secret_factory_by_label()` to `make_key()`/`make_factory()`. ([#71])
 
 
 ### Added
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#65]: https://github.com/nucypher/rust-umbral/pull/65
 [#67]: https://github.com/nucypher/rust-umbral/pull/67
 [#69]: https://github.com/nucypher/rust-umbral/pull/69
+[#71]: https://github.com/nucypher/rust-umbral/pull/71
 
 
 ## [0.2.0] - 2021-06-14

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -123,10 +123,10 @@ API reference
 
     Wrapper for ECDSA signatures.
 
-    .. py:method:: verify(verifying_key: PublicKey, message: bytes) -> bool
+    .. py:method:: verify(verifying_pk: PublicKey, message: bytes) -> bool
 
         Returns ``True`` if the ``message`` was signed by someone possessing the secret counterpart
-        to ``verifying_key``.
+        to ``verifying_pk``.
 
     .. py:method:: __bytes__() -> bytes
 

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -64,11 +64,11 @@ API reference
         **Warning:** make sure the given seed has been obtained
         from a cryptographically secure source of randomness!
 
-    .. py:method:: secret_key_by_label(label: bytes) -> SecretKey
+    .. py:method:: make_key(label: bytes) -> SecretKey
 
         Generates a new :py:class:`SecretKey` using ``label`` as a seed.
 
-    .. py:method:: secret_key_factory_by_label(label: bytes) -> SecretKeyFactory
+    .. py:method:: make_factory(label: bytes) -> SecretKeyFactory
 
         Generates a new :py:class:`SecretKeyFactory` using ``label`` as a seed.
 

--- a/umbral-pre-python/example/example.py
+++ b/umbral-pre-python/example/example.py
@@ -35,14 +35,14 @@ assert plaintext_alice == plaintext
 
 # When Alice wants to grant Bob access to open her encrypted
 # messages, she creates re-encryption key fragments,
-# or "kfrags", which are then sent to `n` proxies or Ursulas.
+# or "kfrags", which are then sent to `shares` proxies or Ursulas.
 
-n = 3 # how many fragments to create
-m = 2 # how many should be enough to decrypt
+shares = 3 # how many fragments to create
+threshold = 2 # how many should be enough to decrypt
 
 # Split Re-Encryption Key Generation (aka Delegation)
 verified_kfrags = umbral_pre.generate_kfrags(
-    alice_sk, bob_pk, signer, m, n,
+    alice_sk, bob_pk, signer, threshold, shares,
     True, # add the delegating key (alice_pk) to the signature
     True, # add the receiving key (bob_pk) to the signature
 )
@@ -54,7 +54,7 @@ verified_kfrags = umbral_pre.generate_kfrags(
 # a "capsule fragment", or cfrag.
 
 # Bob collects the resulting cfrags from several Ursulas.
-# Bob must gather at least `m` cfrags
+# Bob must gather at least `threshold` cfrags
 # in order to open the capsule.
 
 # Simulate network transfer
@@ -78,7 +78,7 @@ verified_cfrag1 = umbral_pre.reencrypt(capsule, kfrags[1])
 cfrag0 = CapsuleFrag.from_bytes(bytes(verified_cfrag0))
 cfrag1 = CapsuleFrag.from_bytes(bytes(verified_cfrag1))
 
-# Finally, Bob opens the capsule by using at least `m` cfrags,
+# Finally, Bob opens the capsule by using at least `threshold` cfrags,
 # and then decrypts the re-encrypted ciphertext.
 
 # Bob must check that cfrags are valid

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -335,8 +335,8 @@ impl Signature {
         from_bytes(data)
     }
 
-    pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
-        self.backend.verify(&verifying_key.backend, message)
+    pub fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
+        self.backend.verify(&verifying_pk.backend, message)
     }
 
     #[staticmethod]

--- a/umbral-pre-python/src/lib.rs
+++ b/umbral-pre-python/src/lib.rs
@@ -183,18 +183,18 @@ impl SecretKeyFactory {
             .map_err(|err| PyValueError::new_err(format!("{}", err)))
     }
 
-    pub fn secret_key_by_label(&self, label: &[u8]) -> PyResult<SecretKey> {
+    pub fn make_key(&self, label: &[u8]) -> PyResult<SecretKey> {
         self.backend
-            .secret_key_by_label(label)
+            .make_key(label)
             .map(|backend_sk| SecretKey {
                 backend: backend_sk,
             })
             .map_err(|err| PyValueError::new_err(format!("{}", err)))
     }
 
-    pub fn secret_key_factory_by_label(&self, label: &[u8]) -> Self {
+    pub fn make_factory(&self, label: &[u8]) -> Self {
         Self {
-            backend: self.backend.secret_key_factory_by_label(label),
+            backend: self.backend.make_factory(label),
         }
     }
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -36,10 +36,10 @@ class SecretKeyFactory:
     def from_secure_randomness(seed: bytes) -> SecretKeyFactory:
         ...
 
-    def secret_key_by_label(self, label: bytes) -> SecretKey:
+    def make_key(self, label: bytes) -> SecretKey:
         ...
 
-    def secret_key_factory_by_label(self, label: bytes) -> SecretKeyFactory:
+    def make_factory(self, label: bytes) -> SecretKeyFactory:
         ...
 
     def to_secret_bytes(self) -> bytes:

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -79,7 +79,7 @@ class Signer:
 
 class Signature:
 
-    def verify(verifying_key: PublicKey, message: bytes) -> bool:
+    def verify(verifying_pk: PublicKey, message: bytes) -> bool:
         ...
 
     @staticmethod

--- a/umbral-pre-wasm/README.md
+++ b/umbral-pre-wasm/README.md
@@ -51,19 +51,19 @@ console.assert(dec.decode(plaintext_alice) === plaintext, "decryptOriginal() fai
 
 // When Alice wants to grant Bob access to open her encrypted messages,
 // she creates re-encryption key fragments, or "kfrags", which are then
-// sent to `n` proxies or Ursulas.
+// sent to `shares` proxies or Ursulas.
 
-let n = 3; // how many fragments to create
-let m = 2; // how many should be enough to decrypt
+let shares = 3; // how many fragments to create
+let threshold = 2; // how many should be enough to decrypt
 let kfrags = umbral.generateKFrags(
-    alice_sk, bob_pk, signer, m, n, true, true);
+    alice_sk, bob_pk, signer, threshold, shares, true, true);
 
 // Bob asks several Ursulas to re-encrypt the capsule so he can open it.
 // Each Ursula performs re-encryption on the capsule using the kfrag provided by Alice,
 // obtaining this way a "capsule fragment", or cfrag.
 
 // Bob collects the resulting cfrags from several Ursulas.
-// Bob must gather at least `m` cfrags in order to open the capsule.
+// Bob must gather at least `threshold` cfrags in order to open the capsule.
 
 // Ursula 0
 let cfrag0 = umbral.reencrypt(capsule, kfrags[0]);
@@ -73,7 +73,7 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 
-// Finally, Bob opens the capsule by using at least `m` cfrags,
+// Finally, Bob opens the capsule by using at least `threshold` cfrags,
 // and then decrypts the re-encrypted ciphertext.
 
 // Another deviation from the Rust API.

--- a/umbral-pre-wasm/examples/bundler/index.js
+++ b/umbral-pre-wasm/examples/bundler/index.js
@@ -39,12 +39,12 @@ console.assert(dec.decode(plaintext_alice) === plaintext, "decryptOriginal() fai
 
 // When Alice wants to grant Bob access to open her encrypted messages,
 // she creates re-encryption key fragments, or "kfrags", which are then
-// sent to `n` proxies or Ursulas.
+// sent to `shares` proxies or Ursulas.
 
-let n = 3; // how many fragments to create
-let m = 2; // how many should be enough to decrypt
+let shares = 3; // how many fragments to create
+let threshold = 2; // how many should be enough to decrypt
 let kfrags = umbral.generateKFrags(
-    alice_sk, bob_pk, signer, m, n,
+    alice_sk, bob_pk, signer, threshold, shares,
     true, // add the delegating key (alice_pk) to the signature
     true, // add the receiving key (bob_pk) to the signature
     );
@@ -54,7 +54,7 @@ let kfrags = umbral.generateKFrags(
 // obtaining this way a "capsule fragment", or cfrag.
 
 // Bob collects the resulting cfrags from several Ursulas.
-// Bob must gather at least `m` cfrags in order to open the capsule.
+// Bob must gather at least `threshold` cfrags in order to open the capsule.
 
 // Ursulas can optionally check that the received kfrags are valid
 // and perform the reencryption
@@ -67,7 +67,7 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 
-// Finally, Bob opens the capsule by using at least `m` cfrags,
+// Finally, Bob opens the capsule by using at least `threshold` cfrags,
 // and then decrypts the re-encrypted ciphertext.
 
 // Another deviation from the Rust API.

--- a/umbral-pre-wasm/examples/node/index.js
+++ b/umbral-pre-wasm/examples/node/index.js
@@ -39,12 +39,12 @@ console.assert(dec.decode(plaintext_alice) === plaintext, "decryptOriginal() fai
 
 // When Alice wants to grant Bob access to open her encrypted messages,
 // she creates re-encryption key fragments, or "kfrags", which are then
-// sent to `n` proxies or Ursulas.
+// sent to `shares` proxies or Ursulas.
 
-let n = 3; // how many fragments to create
-let m = 2; // how many should be enough to decrypt
+let shares = 3; // how many fragments to create
+let threshold = 2; // how many should be enough to decrypt
 let kfrags = umbral.generateKFrags(
-    alice_sk, bob_pk, signer, m, n,
+    alice_sk, bob_pk, signer, threshold, shares,
     true, // add the delegating key (alice_pk) to the signature
     true, // add the receiving key (bob_pk) to the signature
     );
@@ -54,7 +54,7 @@ let kfrags = umbral.generateKFrags(
 // obtaining this way a "capsule fragment", or cfrag.
 
 // Bob collects the resulting cfrags from several Ursulas.
-// Bob must gather at least `m` cfrags in order to open the capsule.
+// Bob must gather at least `threshold` cfrags in order to open the capsule.
 
 // Ursulas can optionally check that the received kfrags are valid
 // and perform the reencryption
@@ -67,7 +67,7 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 
-// Finally, Bob opens the capsule by using at least `m` cfrags,
+// Finally, Bob opens the capsule by using at least `threshold` cfrags,
 // and then decrypts the re-encrypted ciphertext.
 
 // Another deviation from the Rust API.

--- a/umbral-pre-wasm/examples/react/src/App.js
+++ b/umbral-pre-wasm/examples/react/src/App.js
@@ -67,16 +67,16 @@ function App() {
 
     // When Alice wants to grant Bob access to open her encrypted messages,
     // she creates re-encryption key fragments, or "kfrags", which are then
-    // sent to `n` proxies or Ursulas.
+    // sent to `shares` proxies or Ursulas.
 
-    let n = 3; // how many fragments to create
-    let m = 2; // how many should be enough to decrypt
+    let shares = 3; // how many fragments to create
+    let threshold = 2; // how many should be enough to decrypt
     let kfrags = umbral.generateKFrags(
       alice_sk,
       bob_pk,
       signer,
-      m,
-      n,
+      threshold,
+      shares,
       true, // add the delegating key (alice_pk) to the signature
       true // add the receiving key (bob_pk) to the signature
     );
@@ -86,7 +86,7 @@ function App() {
     // obtaining this way a "capsule fragment", or cfrag.
 
     // Bob collects the resulting cfrags from several Ursulas.
-    // Bob must gather at least `m` cfrags in order to open the capsule.
+    // Bob must gather at least `threshold` cfrags in order to open the capsule.
 
     // Ursulas can optionally check that the received kfrags are valid
     // and perform the reencryption
@@ -100,7 +100,7 @@ function App() {
     // ...
     setCfrags([cfrag0, cfrag1]);
 
-    // Finally, Bob opens the capsule by using at least `m` cfrags,
+    // Finally, Bob opens the capsule by using at least `threshold` cfrags,
     // and then decrypts the re-encrypted ciphertext.
 
     // Another deviation from the Rust API.

--- a/umbral-pre-wasm/examples/webpack-5-experiments/index.js
+++ b/umbral-pre-wasm/examples/webpack-5-experiments/index.js
@@ -39,12 +39,12 @@ console.assert(dec.decode(plaintext_alice) === plaintext, "decryptOriginal() fai
 
 // When Alice wants to grant Bob access to open her encrypted messages,
 // she creates re-encryption key fragments, or "kfrags", which are then
-// sent to `n` proxies or Ursulas.
+// sent to `shares` proxies or Ursulas.
 
-let n = 3; // how many fragments to create
-let m = 2; // how many should be enough to decrypt
+let shares = 3; // how many fragments to create
+let threshold = 2; // how many should be enough to decrypt
 let kfrags = umbral.generateKFrags(
-    alice_sk, bob_pk, signer, m, n,
+    alice_sk, bob_pk, signer, threshold, shares,
     true, // add the delegating key (alice_pk) to the signature
     true, // add the receiving key (bob_pk) to the signature
     );
@@ -54,7 +54,7 @@ let kfrags = umbral.generateKFrags(
 // obtaining this way a "capsule fragment", or cfrag.
 
 // Bob collects the resulting cfrags from several Ursulas.
-// Bob must gather at least `m` cfrags in order to open the capsule.
+// Bob must gather at least `threshold` cfrags in order to open the capsule.
 
 // Ursulas can optionally check that the received kfrags are valid
 // and perform the reencryption
@@ -67,7 +67,7 @@ let cfrag1 = umbral.reencrypt(capsule, kfrags[1]);
 
 // ...
 
-// Finally, Bob opens the capsule by using at least `m` cfrags,
+// Finally, Bob opens the capsule by using at least `threshold` cfrags,
 // and then decrypts the re-encrypted ciphertext.
 
 // Another deviation from the Rust API.

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -83,17 +83,14 @@ impl SecretKeyFactory {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen(js_name = secretKeyByLabel)]
-    pub fn secret_key_by_label(&self, label: &[u8]) -> Result<SecretKey, JsValue> {
-        self.0
-            .secret_key_by_label(label)
-            .map(SecretKey)
-            .map_err(map_js_err)
+    #[wasm_bindgen(js_name = makeKey)]
+    pub fn make_key(&self, label: &[u8]) -> Result<SecretKey, JsValue> {
+        self.0.make_key(label).map(SecretKey).map_err(map_js_err)
     }
 
-    #[wasm_bindgen(js_name = secretKeyFactoryByLabel)]
-    pub fn secret_key_factory_by_label(&self, label: &[u8]) -> Self {
-        Self(self.0.secret_key_factory_by_label(label))
+    #[wasm_bindgen(js_name = makeFactory)]
+    pub fn make_factory(&self, label: &[u8]) -> Self {
+        Self(self.0.make_factory(label))
     }
 
     #[wasm_bindgen(js_name = toSecretBytes)]

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -175,8 +175,8 @@ pub struct Signature(umbral_pre::Signature);
 
 #[wasm_bindgen]
 impl Signature {
-    pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
-        self.0.verify(&verifying_key.0, message)
+    pub fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
+        self.0.verify(&verifying_pk.0, message)
     }
 
     #[wasm_bindgen(js_name = toBytes)]

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -70,8 +70,8 @@ impl<'de> Deserialize<'de> for Signature {
 impl Signature {
     /// Verifies that the given message was signed with the secret counterpart of the given key.
     /// The message is hashed internally.
-    pub fn verify(&self, verifying_key: &PublicKey, message: &[u8]) -> bool {
-        verifying_key.verify_digest(digest_for_signing(message), self)
+    pub fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
+        verifying_pk.verify_digest(digest_for_signing(message), self)
     }
 }
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -351,7 +351,7 @@ impl SecretKeyFactory {
     }
 
     /// Creates a `SecretKey` deterministically from the given label.
-    pub fn secret_key_by_label(&self, label: &[u8]) -> Result<SecretKey, SecretKeyFactoryError> {
+    pub fn make_key(&self, label: &[u8]) -> Result<SecretKey, SecretKeyFactoryError> {
         let prefix = b"KEY_DERIVATION/";
         let info: Vec<u8> = prefix
             .iter()
@@ -368,7 +368,7 @@ impl SecretKeyFactory {
     }
 
     /// Creates a `SecretKeyFactory` deterministically from the given label.
-    pub fn secret_key_factory_by_label(&self, label: &[u8]) -> Self {
+    pub fn make_factory(&self, label: &[u8]) -> Self {
         let prefix = b"FACTORY_DERIVATION/";
         let info: Vec<u8> = prefix
             .iter()
@@ -443,9 +443,9 @@ mod tests {
     #[test]
     fn test_secret_key_factory() {
         let skf = SecretKeyFactory::random();
-        let sk1 = skf.secret_key_by_label(b"foo");
-        let sk2 = skf.secret_key_by_label(b"foo");
-        let sk3 = skf.secret_key_by_label(b"bar");
+        let sk1 = skf.make_key(b"foo");
+        let sk2 = skf.make_key(b"foo");
+        let sk3 = skf.make_key(b"bar");
 
         assert!(sk1 == sk2);
         assert!(sk1 != sk3);

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -43,11 +43,11 @@
 //!
 //! // When Alice wants to grant Bob access to open her encrypted messages,
 //! // she creates re-encryption key fragments, or "kfrags", which are then
-//! // sent to `n` proxies or Ursulas.
+//! // sent to `shares` proxies or Ursulas.
 //!
-//! let n = 3; // how many fragments to create
-//! let m = 2; // how many should be enough to decrypt
-//! let verified_kfrags = generate_kfrags(&alice_sk, &bob_pk, &signer, m, n, true, true);
+//! let shares = 3; // how many fragments to create
+//! let threshold = 2; // how many should be enough to decrypt
+//! let verified_kfrags = generate_kfrags(&alice_sk, &bob_pk, &signer, threshold, shares, true, true);
 //!
 //! // Bob asks several Ursulas to re-encrypt the capsule so he can open it.
 //! // Each Ursula performs re-encryption on the capsule using the kfrag provided by Alice,
@@ -58,7 +58,7 @@
 //! let kfrag1 = KeyFrag::from_array(&verified_kfrags[1].to_array()).unwrap();
 //!
 //! // Bob collects the resulting cfrags from several Ursulas.
-//! // Bob must gather at least `m` cfrags in order to open the capsule.
+//! // Bob must gather at least `threshold` cfrags in order to open the capsule.
 //!
 //! // Ursulas must check that the received kfrags are valid
 //! // and perform the reencryption
@@ -77,7 +77,7 @@
 //! let cfrag0 = CapsuleFrag::from_array(&verified_cfrag0.to_array()).unwrap();
 //! let cfrag1 = CapsuleFrag::from_array(&verified_cfrag1.to_array()).unwrap();
 //!
-//! // Finally, Bob opens the capsule by using at least `m` cfrags,
+//! // Finally, Bob opens the capsule by using at least `threshold` cfrags,
 //! // and then decrypts the re-encrypted ciphertext.
 //!
 //! // Bob must check that cfrags are valid


### PR DESCRIPTION
Fixes #33 

- renames `SecretKeyFactory::secret_key_by_label()`/`secret_factory_by_label()` -> `make_key()`/`make_factory()`. The former names were way too wordy.
- replaces remaining (from #69) instances of `m`/`n` with `threshold`/`shares`.
- replaces `verifying_key` parameter in `Signature::verify()` with `verifying_pk` - it is called like that everywhere else.