### PR TITLE
Gate `serde` support under a feature

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -104,7 +104,7 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --release --target ${{ matrix.target }}
+      - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   trigger-wheels:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+- `serde` support for types is now gated under the `serde-support` feature (not enabled by default). ([#82])
+
+
+[#82]: https://github.com/nucypher/rust-umbral/pull/82
 
 
 ## [0.3.3] - 2021-12-10

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
 hkdf = { version = "0.11", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-serde = { version = "1", default-features = false }
+serde = { version = "1", default-features = false, optional = true }
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 
 # These packages are among the dependencies of the packages above.
@@ -41,6 +41,7 @@ rmp-serde = "0.15"
 default = ["default-rng"]
 bench-internals = ["default-rng"]
 default-rng = ["getrandom", "rand_core/getrandom"]
+serde-support = ["serde"]
 
 [[bench]]
 name = "bench"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -43,6 +43,12 @@ bench-internals = ["default-rng"]
 default-rng = ["getrandom", "rand_core/getrandom"]
 serde-support = ["serde"]
 
+# What features to use when building documentation on docs.rs
+[package.metadata.docs.rs]
+features = ["serde-support"]
+# Used to conditionally enable the unstable feature `doc-cfg`
+rustc-args = ["--cfg", "docsrs"]
+
 [[bench]]
 name = "bench"
 path = "bench/bench.rs"

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -4,8 +4,10 @@ use core::fmt;
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typenum::op;
+
+#[cfg(feature = "serde-support")]
+use crate::serde::{serde_deserialize, serde_serialize, Representation};
 
 use crate::capsule_frag::CapsuleFrag;
 use crate::curve::{CurvePoint, CurveScalar};
@@ -13,11 +15,13 @@ use crate::hashing_ds::{hash_capsule_points, hash_to_polynomial_arg, hash_to_sha
 use crate::keys::{PublicKey, SecretKey};
 use crate::params::Parameters;
 use crate::secret_box::SecretBox;
-use crate::serde::{serde_deserialize, serde_serialize, Representation};
 use crate::traits::{
     fmt_public, ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
     SerializableToArray,
 };
+
+#[cfg(feature = "serde-support")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Errors that can happen when opening a `Capsule` using reencrypted `CapsuleFrag` objects.
 #[derive(Debug, PartialEq)]
@@ -86,6 +90,7 @@ impl DeserializableFromArray for Capsule {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl Serialize for Capsule {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -95,6 +100,7 @@ impl Serialize for Capsule {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl<'de> Deserialize<'de> for Capsule {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -263,12 +269,17 @@ mod tests {
     use rand_core::OsRng;
 
     use super::{Capsule, OpenReencryptedError};
-    use crate::serde::tests::{check_deserialization, check_serialization};
-    use crate::serde::Representation;
+
     use crate::{
         encrypt, generate_kfrags, reencrypt, DeserializableFromArray, SecretKey,
         SerializableToArray, Signer,
     };
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::tests::{check_deserialization, check_serialization};
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::Representation;
 
     #[test]
     fn test_serialize() {
@@ -347,6 +358,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde_serialization() {
         let delegating_sk = SecretKey::random();

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -91,6 +91,7 @@ impl DeserializableFromArray for Capsule {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl Serialize for Capsule {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -101,6 +102,7 @@ impl Serialize for Capsule {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl<'de> Deserialize<'de> for Capsule {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -3,19 +3,23 @@ use core::fmt;
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typenum::op;
+
+#[cfg(feature = "serde-support")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::capsule::Capsule;
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
-use crate::serde::{serde_deserialize, serde_serialize, Representation};
 use crate::traits::{
     fmt_public, ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray,
 };
+
+#[cfg(feature = "serde-support")]
+use crate::serde::{serde_deserialize, serde_serialize, Representation};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CapsuleFragProof {
@@ -156,6 +160,7 @@ impl DeserializableFromArray for CapsuleFrag {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl Serialize for CapsuleFrag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -165,6 +170,7 @@ impl Serialize for CapsuleFrag {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl<'de> Deserialize<'de> for CapsuleFrag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -349,12 +355,17 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::{CapsuleFrag, VerifiedCapsuleFrag};
-    use crate::serde::tests::{check_deserialization, check_serialization};
-    use crate::serde::Representation;
+
     use crate::{
         encrypt, generate_kfrags, reencrypt, Capsule, DeserializableFromArray, PublicKey,
         SecretKey, SerializableToArray, Signer,
     };
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::tests::{check_deserialization, check_serialization};
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::Representation;
 
     fn prepare_cfrags() -> (
         PublicKey,
@@ -411,6 +422,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde_serialization() {
         let (_delegating_pk, _receiving_pk, _verifying_pk, _capsule, verified_cfrags) =

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -161,6 +161,7 @@ impl DeserializableFromArray for CapsuleFrag {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl Serialize for CapsuleFrag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -171,6 +172,7 @@ impl Serialize for CapsuleFrag {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl<'de> Deserialize<'de> for CapsuleFrag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -208,6 +208,7 @@ impl DeserializableFromArray for KeyFrag {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl Serialize for KeyFrag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -218,6 +219,7 @@ impl Serialize for KeyFrag {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl<'de> Deserialize<'de> for KeyFrag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -5,18 +5,22 @@ use core::fmt;
 use generic_array::sequence::Concat;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typenum::{op, U32};
+
+#[cfg(feature = "serde-support")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::curve::{CurvePoint, CurveScalar};
 use crate::hashing_ds::{hash_to_polynomial_arg, hash_to_shared_secret, kfrag_signature_message};
 use crate::keys::{PublicKey, SecretKey, Signature, Signer};
 use crate::params::Parameters;
-use crate::serde::{serde_deserialize, serde_serialize, Representation};
 use crate::traits::{
     fmt_public, ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray,
 };
+
+#[cfg(feature = "serde-support")]
+use crate::serde::{serde_deserialize, serde_serialize, Representation};
 
 #[allow(clippy::upper_case_acronyms)]
 type KeyFragIDSize = U32;
@@ -203,6 +207,7 @@ impl DeserializableFromArray for KeyFrag {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl Serialize for KeyFrag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -212,6 +217,7 @@ impl Serialize for KeyFrag {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl<'de> Deserialize<'de> for KeyFrag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -491,9 +497,14 @@ mod tests {
     use rand_core::OsRng;
 
     use super::{KeyFrag, KeyFragBase, KeyFragVerificationError, VerifiedKeyFrag};
-    use crate::serde::tests::{check_deserialization, check_serialization};
-    use crate::serde::Representation;
+
     use crate::{DeserializableFromArray, PublicKey, SecretKey, SerializableToArray, Signer};
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::tests::{check_deserialization, check_serialization};
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::Representation;
 
     fn prepare_kfrags(
         sign_delegating_key: bool,
@@ -562,6 +573,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde_serialization() {
         let (_delegating_pk, _receiving_pk, _verifying_pk, verified_kfrags) =

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -54,6 +54,7 @@ impl DeserializableFromArray for Signature {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -64,6 +65,7 @@ impl Serialize for Signature {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl<'de> Deserialize<'de> for Signature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -115,6 +117,7 @@ impl SecretKey {
 
     /// Creates a secret key using the default RNG.
     #[cfg(feature = "default-rng")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn random() -> Self {
         Self::random_with_rng(&mut OsRng)
     }
@@ -200,6 +203,7 @@ impl Signer {
 
     /// Signs the given message using the default RNG.
     #[cfg(feature = "default-rng")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn sign(&self, message: &[u8]) -> Signature {
         self.sign_with_rng(&mut OsRng, message)
     }
@@ -265,6 +269,7 @@ impl DeserializableFromArray for PublicKey {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -275,6 +280,7 @@ impl Serialize for PublicKey {
 }
 
 #[cfg(feature = "serde-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -331,6 +337,7 @@ impl SecretKeyFactory {
 
     /// Creates a secret key factory using the default RNG.
     #[cfg(feature = "default-rng")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn random() -> Self {
         Self::random_with_rng(&mut OsRng)
     }

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -8,22 +8,26 @@ use ecdsa::{Signature as BackendSignature, SignatureSize, SigningKey, VerifyingK
 use elliptic_curve::{PublicKey as BackendPublicKey, SecretKey as BackendSecretKey};
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use signature::{DigestVerifier, RandomizedDigestSigner, Signature as SignatureTrait};
 use typenum::{Unsigned, U32, U64};
 
 #[cfg(feature = "default-rng")]
 use rand_core::OsRng;
 
+#[cfg(feature = "serde-support")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::curve::{BackendNonZeroScalar, CurvePoint, CurveScalar, CurveType};
 use crate::dem::kdf;
 use crate::hashing::{BackendDigest, Hash, ScalarDigest};
 use crate::secret_box::{CanBeZeroizedOnDrop, SecretBox};
-use crate::serde::{serde_deserialize, serde_serialize, Representation};
 use crate::traits::{
     fmt_public, fmt_secret, ConstructionError, DeserializableFromArray, HasTypeName,
     RepresentableAsArray, SerializableToArray, SerializableToSecretArray, SizeMismatchError,
 };
+
+#[cfg(feature = "serde-support")]
+use crate::serde::{serde_deserialize, serde_serialize, Representation};
 
 /// ECDSA signature object.
 #[derive(Clone, Debug, PartialEq)]
@@ -49,6 +53,7 @@ impl DeserializableFromArray for Signature {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -58,6 +63,7 @@ impl Serialize for Signature {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl<'de> Deserialize<'de> for Signature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -258,6 +264,7 @@ impl DeserializableFromArray for PublicKey {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -267,6 +274,7 @@ impl Serialize for PublicKey {
     }
 }
 
+#[cfg(feature = "serde-support")]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -420,9 +428,12 @@ impl fmt::Display for SecretKeyFactory {
 mod tests {
 
     use super::{PublicKey, SecretKey, SecretKeyFactory, Signer};
-    use crate::serde::tests::{check_deserialization, check_serialization};
-    use crate::serde::Representation;
     use crate::{DeserializableFromArray, SerializableToArray, SerializableToSecretArray};
+
+    #[cfg(feature = "serde-support")]
+    use crate::serde::tests::{check_deserialization, check_serialization};
+    #[cfg(feature = "serde-support")]
+    use crate::serde::Representation;
 
     #[test]
     fn test_serialize_secret_key() {
@@ -474,6 +485,7 @@ mod tests {
         assert!(signature.verify(&vk, message));
     }
 
+    #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde_serialization() {
         let sk = SecretKey::random();

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -8,6 +8,11 @@
 //! Bob is able to combine these independent re-encryptions and decrypt the original message
 //! using his private key.
 //!
+//! ## Available feature flags
+//!
+//! * `default-rng` - adds methods that use the system RNG (default).
+//! * `serde-support` - implements `serde`-based serialization and deserialization.
+//!
 //! # Usage
 //!
 //! ```
@@ -99,6 +104,8 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![no_std]
+// Allows us to mark items in the documentation as gated under specific features.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -116,8 +116,10 @@ mod keys;
 mod params;
 mod pre;
 mod secret_box;
-mod serde;
 mod traits;
+
+#[cfg(feature = "serde-support")]
+mod serde;
 
 pub use capsule::{Capsule, OpenReencryptedError};
 pub use capsule_frag::{CapsuleFrag, CapsuleFragVerificationError, VerifiedCapsuleFrag};

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -51,6 +51,7 @@ pub fn encrypt_with_rng(
 
 /// A synonym for [`encrypt`] with the default RNG.
 #[cfg(feature = "default-rng")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 pub fn encrypt(
     delegating_pk: &PublicKey,
     plaintext: &[u8],
@@ -113,6 +114,7 @@ pub fn generate_kfrags_with_rng(
 
 /// A synonym for [`generate_kfrags_with_rng`] with the default RNG.
 #[cfg(feature = "default-rng")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 #[allow(clippy::too_many_arguments)]
 pub fn generate_kfrags(
     delegating_sk: &SecretKey,
@@ -153,6 +155,7 @@ pub fn reencrypt_with_rng(
 
 /// A synonym for [`reencrypt_with_rng`] with the default RNG.
 #[cfg(feature = "default-rng")]
+#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 pub fn reencrypt(capsule: &Capsule, verified_kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
     reencrypt_with_rng(&mut OsRng, capsule, verified_kfrag)
 }


### PR DESCRIPTION
`serde` is a pretty fat crate and is not needed for JS/Python bindings (and possibly not needed by many users of the main crate either). So this PR hides it under an optional feature.

Also it adds a list of available feature to the docs and marks gated methods with a `doc` attribute.