### PR TITLE
Fix python sdist

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,9 +97,22 @@ jobs:
         run: |
           python -m pip install --upgrade wheel setuptools setuptools-rust
 
+      # Assuming here that the version of the Python bindings
+      # is matched to the version of the main Rust crate (as it should be at all times),
+      # and we are running this at a release commit.
+      - name: Replace the relative path to `umbral-pre` in Cargo.toml with the specific version
+        working-directory: ./umbral-pre-python
+        run: python replace_version.py relative-to-published
+
       - name: Build sdist
         working-directory: ./umbral-pre-python
         run: python setup.py sdist
+
+      # Roll back the changes
+      - name: Replace the specific version of `umbral-pre` in Cargo.toml with the relative path
+        if: always()
+        working-directory: ./umbral-pre-python
+        run: python replace_version.py published-to-relative
 
       - uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 the corresponding methods in Python and WASM bindings. ([#84])
 
 
+### Fixed
+
+- Make the source distribution of Python bindings actually usable, by removing a dependency on a workspace directory. ([#86])
+
+
 [#74]: https://github.com/nucypher/rust-umbral/pull/74
 [#82]: https://github.com/nucypher/rust-umbral/pull/82
 [#84]: https://github.com/nucypher/rust-umbral/pull/84
+[#86]: https://github.com/nucypher/rust-umbral/pull/86
 
 
 ## [0.3.3] - 2021-12-10

--- a/umbral-pre-python/MANIFEST.in
+++ b/umbral-pre-python/MANIFEST.in
@@ -2,3 +2,8 @@ include Cargo.toml
 include README.md
 include LICENSE
 recursive-include src *
+recursive-include example *.py
+recursive-include docs *.rst
+include docs/Makefile
+include docs/make.bat
+include docs/conf.py

--- a/umbral-pre-python/replace_version.py
+++ b/umbral-pre-python/replace_version.py
@@ -1,0 +1,73 @@
+"""
+This script is used to build a source distribution in CI.
+During development it is convenient to have a relative path to `umbral-pre` in `Cargo.toml`,
+but since the source distribution will not include the main crate,
+we need to re-set it to the published version (and then change it back).
+
+See https://github.com/nucypher/rust-umbral/issues/80
+"""
+
+import sys
+import re
+
+
+def get_version():
+
+    with open('Cargo.toml') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        m = re.match(r'^version = "(\d+\.\d+\.\d+)"$', line)
+        if m:
+            version = m.group(1)
+            break
+    else:
+        raise RuntimeError("Cannot find the package version")
+
+    return version
+
+def relative_to_published():
+
+    version = get_version()
+
+    with open('Cargo.toml') as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        if line.startswith('umbral-pre = { path = "../umbral-pre"'):
+            new_line = line.replace('path = "../umbral-pre"', f'version = "{version}"')
+            lines[i] = new_line
+            break
+    else:
+        raise RuntimeError("Cannot find the umbral-pre dependency")
+
+    with open('Cargo.toml', 'w') as f:
+        f.write(''.join(lines))
+
+
+def published_to_relative():
+
+    version = get_version()
+
+    with open('Cargo.toml') as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        if line.startswith(f'umbral-pre = {{ version = "{version}"'):
+            new_line = line.replace(f'version = "{version}"', 'path = "../umbral-pre"')
+            lines[i] = new_line
+            break
+    else:
+        raise RuntimeError("Cannot find the umbral-pre dependency")
+
+    with open('Cargo.toml', 'w') as f:
+        f.write(''.join(lines))
+
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'relative-to-published':
+        relative_to_published()
+    elif sys.argv[1] == 'published-to-relative':
+        published_to_relative()
+    else:
+        raise RuntimeError(f"Unknown command: {sys.argv[1]}")


### PR DESCRIPTION
- add docs and examples in the manifest
- fix the path to `umbral-pre` at `sdist` CI step (fixes #80)