### PR TITLE
Bump k256 version and use the new functionality

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0 # MSRV
+        toolchain: 1.56.0 # MSRV
         components: clippy
         override: true
         profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing here yet.
+### Changed
+
+- `k256` dependency bumped to 0.10 (and to match it, `chacha20poly1305` to 0.9, `elliptic-curve` to 0.11, `ecdsa` to 0.13, `signature` to 1.4, MSRV to 1.56, and Rust edition to 2021). ([#87])
+- ABI changed because of the internal change in hashing to scalars (we can hash to non-zero scalars now). Correspondingly, `OpenReencryptedError::ZeroHash` and `SecretKeyFactoryError` have been removed, and `SecretKeyFactory::make_key()` was made infallible. ([#87])
+
+
+### Fixed
+
+- Some previously missed potentially secret values are zeroized in drop. ([#87])
+
+
+[#87]: https://github.com/nucypher/rust-umbral/pull/87
 
 
 ## [0.4.0] - 2021-12-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ members = [
     "umbral-pre-wasm",
     "umbral-pre-python",
 ]
-
-# Prevents feature conflicts between [dependencies] and [dev-dependencies]
-# Will be the default in 2021 edition.
-resolver = "2"

--- a/umbral-pre-python/Cargo.toml
+++ b/umbral-pre-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "umbral-pre-python"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
 version = "0.4.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/umbral-pre-wasm/Cargo.toml
+++ b/umbral-pre-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "umbral-pre-wasm"
 version = "0.4.0"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-only"
 description = "Implementation of Umbral proxy reencryption algorithm"
 repository = "https://github.com/nucypher/rust-umbral/tree/master/umbral-pre-wasm"

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -84,8 +84,8 @@ impl SecretKeyFactory {
     }
 
     #[wasm_bindgen(js_name = makeKey)]
-    pub fn make_key(&self, label: &[u8]) -> Result<SecretKey, JsValue> {
-        self.0.make_key(label).map(SecretKey).map_err(map_js_err)
+    pub fn make_key(&self, label: &[u8]) -> SecretKey {
+        SecretKey(self.0.make_key(label))
     }
 
     #[wasm_bindgen(js_name = makeFactory)]

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -24,7 +24,7 @@ pyo3 = { version = "0.15", optional = true }
 elliptic-curve = { version = "0.11" }
 digest = "0.9"
 generic-array = "0.14"
-aead = { version = "0.4", features = ["heapless"] }
+aead = { version = "0.4", default-features = false }
 ecdsa = { version = "0.13" }
 signature = { version = "1.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.10", default-features = false, features = ["ecdsa", "arithmetic"] }
+k256 = { version = "0.10.1", default-features = false, features = ["ecdsa", "arithmetic"] }
 sha2 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.9" }
 hkdf = { version = "0.11", default-features = false }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -2,7 +2,7 @@
 name = "umbral-pre"
 version = "0.4.0"
 authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-only"
 description = "Implementation of Umbral proxy reencryption algorithm"
 repository = "https://github.com/nucypher/rust-umbral/tree/master/umbral-pre"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,9 +10,9 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.9", default-features = false, features = ["ecdsa", "arithmetic", "zeroize"] }
+k256 = { version = "0.10", default-features = false, features = ["ecdsa", "arithmetic"] }
 sha2 = { version = "0.9", default-features = false }
-chacha20poly1305 = { version = "0.8", features = ["xchacha20poly1305"] }
+chacha20poly1305 = { version = "0.9" }
 hkdf = { version = "0.11", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, optional = true }
@@ -21,12 +21,12 @@ pyo3 = { version = "0.15", optional = true }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
-elliptic-curve = { version = "0.10", features = ["zeroize"] }
+elliptic-curve = { version = "0.11" }
 digest = "0.9"
 generic-array = "0.14"
 aead = { version = "0.4", features = ["heapless"] }
-ecdsa = { version = "0.12.2", features = ["zeroize"] }
-signature = { version = "1.3", default-features = false }
+ecdsa = { version = "0.13" }
+signature = { version = "1.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -194,13 +194,10 @@ impl SecretKeyFactory {
             .map_err(|err| PyValueError::new_err(format!("{}", err)))
     }
 
-    pub fn make_key(&self, label: &[u8]) -> PyResult<SecretKey> {
-        self.backend
-            .make_key(label)
-            .map(|backend_sk| SecretKey {
-                backend: backend_sk,
-            })
-            .map_err(|err| PyValueError::new_err(format!("{}", err)))
+    pub fn make_key(&self, label: &[u8]) -> SecretKey {
+        SecretKey {
+            backend: self.backend.make_key(label),
+        }
     }
 
     pub fn make_factory(&self, label: &[u8]) -> Self {

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -158,17 +158,18 @@ impl Capsule {
     ) -> (Capsule, SecretBox<KeySeed>) {
         let g = CurvePoint::generator();
 
-        let priv_r = NonZeroCurveScalar::random(rng);
-        let pub_r = &g * &priv_r;
+        let priv_r = SecretBox::new(NonZeroCurveScalar::random(rng));
+        let pub_r = &g * priv_r.as_secret();
 
-        let priv_u = NonZeroCurveScalar::random(rng);
-        let pub_u = &g * &priv_u;
+        let priv_u = SecretBox::new(NonZeroCurveScalar::random(rng));
+        let pub_u = &g * priv_u.as_secret();
 
         let h = hash_capsule_points(&pub_r, &pub_u);
 
-        let s = &priv_u + &(&priv_r * &h);
+        let s = priv_u.as_secret() + &(priv_r.as_secret() * &h);
 
-        let shared_key = SecretBox::new(&delegating_pk.to_point() * &(&priv_r + &priv_u));
+        let shared_key =
+            SecretBox::new(&delegating_pk.to_point() * &(priv_r.as_secret() + priv_u.as_secret()));
 
         let capsule = Self::new(pub_r, pub_u, s);
 

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -9,7 +9,7 @@ use typenum::op;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::capsule::Capsule;
-use crate::curve::{CurvePoint, CurveScalar};
+use crate::curve::{CurvePoint, CurveScalar, NonZeroCurveScalar};
 use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
@@ -84,7 +84,7 @@ impl CapsuleFragProof {
         let params = capsule.params;
 
         let rk = kfrag.key;
-        let t = CurveScalar::random_nonzero(rng);
+        let t = NonZeroCurveScalar::random(rng);
 
         // Here are the formulaic constituents shared with `CapsuleFrag::verify()`.
 
@@ -105,7 +105,7 @@ impl CapsuleFragProof {
 
         ////////
 
-        let z3 = &t + &(&rk * &h);
+        let z3 = &(&rk * &h) + &t;
 
         Self {
             point_e2: e2,

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -13,6 +13,7 @@ use crate::curve::{CurvePoint, CurveScalar, NonZeroCurveScalar};
 use crate::hashing_ds::{hash_to_cfrag_verification, kfrag_signature_message};
 use crate::key_frag::{KeyFrag, KeyFragID};
 use crate::keys::{PublicKey, Signature};
+use crate::secret_box::SecretBox;
 use crate::traits::{
     fmt_public, ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray,
@@ -84,7 +85,7 @@ impl CapsuleFragProof {
         let params = capsule.params;
 
         let rk = kfrag.key;
-        let t = NonZeroCurveScalar::random(rng);
+        let t = SecretBox::new(NonZeroCurveScalar::random(rng));
 
         // Here are the formulaic constituents shared with `CapsuleFrag::verify()`.
 
@@ -97,15 +98,15 @@ impl CapsuleFragProof {
         let u = params.u;
         let u1 = kfrag.proof.commitment;
 
-        let e2 = &e * &t;
-        let v2 = &v * &t;
-        let u2 = &u * &t;
+        let e2 = &e * t.as_secret();
+        let v2 = &v * t.as_secret();
+        let u2 = &u * t.as_secret();
 
         let h = hash_to_cfrag_verification(&[e, *e1, e2, v, *v1, v2, u, u1, u2]);
 
         ////////
 
-        let z3 = &(&rk * &h) + &t;
+        let z3 = &(&rk * &h) + t.as_secret();
 
         Self {
             point_e2: e2,

--- a/umbral-pre/src/hashing_ds.rs
+++ b/umbral-pre/src/hashing_ds.rs
@@ -4,19 +4,18 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use crate::curve::{CurvePoint, CurveScalar};
+use crate::curve::{CurvePoint, NonZeroCurveScalar};
 use crate::hashing::ScalarDigest;
 use crate::key_frag::KeyFragID;
 use crate::keys::PublicKey;
 use crate::traits::SerializableToArray;
 
-// TODO (#39): Ideally this should return a non-zero scalar.
 pub(crate) fn hash_to_polynomial_arg(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,
     dh_point: &CurvePoint,
     kfrag_id: &KeyFragID,
-) -> CurveScalar {
+) -> NonZeroCurveScalar {
     ScalarDigest::new_with_dst(b"POLYNOMIAL_ARG")
         .chain_point(precursor)
         .chain_point(pubkey)
@@ -29,7 +28,7 @@ pub(crate) fn hash_to_shared_secret(
     precursor: &CurvePoint,
     pubkey: &CurvePoint,
     dh_point: &CurvePoint,
-) -> CurveScalar {
+) -> NonZeroCurveScalar {
     ScalarDigest::new_with_dst(b"SHARED_SECRET")
         .chain_point(precursor)
         .chain_point(pubkey)
@@ -37,14 +36,17 @@ pub(crate) fn hash_to_shared_secret(
         .finalize()
 }
 
-pub(crate) fn hash_capsule_points(capsule_e: &CurvePoint, capsule_v: &CurvePoint) -> CurveScalar {
+pub(crate) fn hash_capsule_points(
+    capsule_e: &CurvePoint,
+    capsule_v: &CurvePoint,
+) -> NonZeroCurveScalar {
     ScalarDigest::new_with_dst(b"CAPSULE_POINTS")
         .chain_point(capsule_e)
         .chain_point(capsule_v)
         .finalize()
 }
 
-pub(crate) fn hash_to_cfrag_verification(points: &[CurvePoint]) -> CurveScalar {
+pub(crate) fn hash_to_cfrag_verification(points: &[CurvePoint]) -> NonZeroCurveScalar {
     ScalarDigest::new_with_dst(b"CFRAG_VERIFICATION")
         .chain_points(points)
         .finalize()

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -10,7 +10,7 @@ use typenum::{op, U32};
 #[cfg(feature = "serde-support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::curve::{CurvePoint, CurveScalar};
+use crate::curve::{CurvePoint, CurveScalar, NonZeroCurveScalar};
 use crate::hashing_ds::{hash_to_polynomial_arg, hash_to_shared_secret, kfrag_signature_message};
 use crate::keys::{PublicKey, SecretKey, Signature, Signer};
 use crate::params::Parameters;
@@ -440,7 +440,7 @@ pub(crate) struct KeyFragBase {
     params: Parameters,
     delegating_pk: PublicKey,
     receiving_pk: PublicKey,
-    coefficients: Box<[CurveScalar]>,
+    coefficients: Box<[NonZeroCurveScalar]>,
 }
 
 impl KeyFragBase {
@@ -458,32 +458,23 @@ impl KeyFragBase {
 
         let receiving_pk_point = receiving_pk.to_point();
 
-        let (d, precursor, dh_point) = loop {
-            // The precursor point is used as an ephemeral public key in a DH key exchange,
-            // and the resulting shared secret 'dh_point' is used to derive other secret values
-            let private_precursor = CurveScalar::random_nonzero(rng);
-            let precursor = &g * &private_precursor;
+        // The precursor point is used as an ephemeral public key in a DH key exchange,
+        // and the resulting shared secret 'dh_point' is used to derive other secret values
+        let private_precursor = NonZeroCurveScalar::random(rng);
+        let precursor = &g * &private_precursor;
 
-            let dh_point = &receiving_pk_point * &private_precursor;
+        let dh_point = &receiving_pk_point * &private_precursor;
 
-            // Secret value 'd' allows to make Umbral non-interactive
-            let d = hash_to_shared_secret(&precursor, &receiving_pk_point, &dh_point);
-
-            // At the moment we cannot statically ensure `d` is a `NonZeroScalar`,
-            // but we need it to be non-zero for the algorithm to work.
-            if !d.is_zero() {
-                break (d, precursor, dh_point);
-            }
-        };
+        // Secret value 'd' allows to make Umbral non-interactive
+        let d = hash_to_shared_secret(&precursor, &receiving_pk_point, &dh_point);
 
         // Coefficients of the generating polynomial
-        // `invert()` is guaranteed not to panic because `d` is nonzero.
-        let coefficient0 = delegating_sk.to_secret_scalar().as_secret() * &(d.invert().unwrap());
+        let coefficient0 = delegating_sk.to_secret_scalar().as_secret() * &(d.invert());
 
-        let mut coefficients = Vec::<CurveScalar>::with_capacity(threshold);
+        let mut coefficients = Vec::<NonZeroCurveScalar>::with_capacity(threshold);
         coefficients.push(coefficient0);
         for _i in 1..threshold {
-            coefficients.push(CurveScalar::random_nonzero(rng));
+            coefficients.push(NonZeroCurveScalar::random(rng));
         }
 
         Self {
@@ -499,8 +490,8 @@ impl KeyFragBase {
 }
 
 // Coefficients of the generating polynomial
-fn poly_eval(coeffs: &[CurveScalar], x: &CurveScalar) -> CurveScalar {
-    let mut result: CurveScalar = coeffs[coeffs.len() - 1];
+fn poly_eval(coeffs: &[NonZeroCurveScalar], x: &NonZeroCurveScalar) -> CurveScalar {
+    let mut result: CurveScalar = (&coeffs[coeffs.len() - 1]).into();
     for i in (0..coeffs.len() - 1).rev() {
         result = &(&result * x) + &coeffs[i];
     }

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -140,7 +140,7 @@ pub use capsule::{Capsule, OpenReencryptedError};
 pub use capsule_frag::{CapsuleFrag, CapsuleFragVerificationError, VerifiedCapsuleFrag};
 pub use dem::{DecryptionError, EncryptionError};
 pub use key_frag::{KeyFrag, KeyFragVerificationError, VerifiedKeyFrag};
-pub use keys::{PublicKey, SecretKey, SecretKeyFactory, SecretKeyFactoryError, Signature, Signer};
+pub use keys::{PublicKey, SecretKey, SecretKeyFactory, Signature, Signer};
 pub use pre::{
     decrypt_original, decrypt_reencrypted, encrypt_with_rng, generate_kfrags_with_rng,
     reencrypt_with_rng, ReencryptionError,


### PR DESCRIPTION
- bumps `k256` dependency to 0.10.1 (.1 supports `ReduceNonZero<U256>` that we need), and the sub-dependencies accordingly. 
- bumps MSRV to 1.56 and rust edition to 2021 (`k256` 0.10 requirement)
- uses the new non-zero scalar functionality (reduction to a non-zero scalar and random non-zero scalars). Everywhere where non-zero scalars are used in the code they now have their own `NonZeroCurveScalar` type (a wrapper for the backend type). Fixes #39. 
- as a consequence of the previous item, `ZeroHash` errors were removed
- the methods that could previously fail because if hash-to-scalar returned 0 are now infallible.
- adds arithmetic impls for operations on `NonZeroCurveScalar` so that it could be used transparently in the code. If https://github.com/RustCrypto/traits/pull/857 is merged, the impl for `NonZeroCurveScalar * NonZeroCurveScalar` can be simplified.  
- added usage of `SecretBox` in some places to wrap secret data. Filed #89 to be fixed when `ZeroizeOnDrop` is available.

If https://github.com/RustCrypto/elliptic-curves/issues/499 is resolved before this PR is merged (unlikely, but who knows), `NonZeroCurveScalar::invert()` can be simplified.