### PR TITLE
Remove `clone()` calls from library internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `k256` dependency bumped to 0.10 (and to match it, `chacha20poly1305` to 0.9, `elliptic-curve` to 0.11, `ecdsa` to 0.13, `signature` to 1.4, MSRV to 1.56, and Rust edition to 2021). ([#87])
 - ABI changed because of the internal change in hashing to scalars (we can hash to non-zero scalars now). Correspondingly, `OpenReencryptedError::ZeroHash` and `SecretKeyFactoryError` have been removed, and `SecretKeyFactory::make_key()` was made infallible. ([#87])
+- Internal cloning in the library methods was eliminated, and, as a result, several methods now consume the given objects. Namely: `Signer::new()` consumes the given `SecretKey`,
+`KeyFrag::verify()` and `CapsuleFrag::verify()` consume the given kfrag/cfrag, `reencrypt()` consumes the cfrag (but not the capsule). ([#91])
+- As a consequence, `KeyFrag::verify()` and `CapsuleFrag::verify()` return the original frag on error (as a tuple with the error itself), for logging purposes (since the original object is not available anymore). ([#91])
+- `VerifiedKeyFrag::to_unverified()` and `VerifiedCapsuleFrag::to_unverified()` were renamed to `unverify()` and consume the corresponding frag. ([#91])
 
 
 ### Fixed
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [#87]: https://github.com/nucypher/rust-umbral/pull/87
+[#91]: https://github.com/nucypher/rust-umbral/pull/91
 
 
 ## [0.4.0] - 2021-12-24

--- a/umbral-pre-python/docs/index.rst
+++ b/umbral-pre-python/docs/index.rst
@@ -227,7 +227,7 @@ API reference
         Intended for internal storage;
         make sure that the bytes come from a trusted source.
 
-    .. py:method:: to_unverified() -> KeyFrag:
+    .. py:method:: unverify() -> KeyFrag:
 
         Clears the verification status from the keyfrag.
         Useful for the cases where it needs to be put in the protocol structure containing :py:class:`KeyFrag` types (since those are the ones that can be serialized/deserialized freely).
@@ -285,7 +285,7 @@ API reference
         Intended for internal storage;
         make sure that the bytes come from a trusted source.
 
-    .. py:method:: to_unverified() -> KeyFrag:
+    .. py:method:: unverify() -> KeyFrag:
 
         Clears the verification status from the capsule frag.
         Useful for the cases where it needs to be put in the protocol structure containing :py:class:`CapsuleFrag` types (since those are the ones that can be serialized/deserialized freely).

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -133,7 +133,7 @@ class VerifiedKeyFrag:
     def from_verified_bytes(data: bytes) -> VerifiedKeyFrag:
         ...
 
-    def to_unverified(self) -> KeyFrag:
+    def unverify(self) -> KeyFrag:
         ...
 
     @staticmethod
@@ -181,7 +181,7 @@ class VerifiedCapsuleFrag:
     def from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag:
         ...
 
-    def to_unverified(self) -> CapsuleFrag:
+    def unverify(self) -> CapsuleFrag:
         ...
 
     @staticmethod

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -257,6 +257,7 @@ impl CapsuleFrag {
         receiving_pk: &PublicKey,
     ) -> Result<VerifiedCapsuleFrag, JsValue> {
         self.0
+            .clone()
             .verify(
                 &capsule.0,
                 &verifying_pk.0,

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -309,9 +309,9 @@ impl VerifiedCapsuleFrag {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen(js_name = toUnverified)]
-    pub fn to_unverified(&self) -> CapsuleFrag {
-        CapsuleFrag(self.0.to_unverified())
+    #[wasm_bindgen(js_name = unverify)]
+    pub fn unverify(&self) -> CapsuleFrag {
+        CapsuleFrag(self.0.clone().unverify())
     }
 
     #[wasm_bindgen(js_name = toBytes)]
@@ -361,7 +361,7 @@ impl CapsuleWithFrags {
             &receiving_sk.0,
             &delegating_pk.0,
             &self.capsule.0,
-            backend_cfrags.as_slice(),
+            backend_cfrags,
             ciphertext,
         )
         .map_err(map_js_err)
@@ -513,9 +513,9 @@ impl VerifiedKeyFrag {
             .map_err(map_js_err)
     }
 
-    #[wasm_bindgen(js_name = toUnverified)]
-    pub fn to_unverified(&self) -> KeyFrag {
-        KeyFrag(self.0.to_unverified())
+    #[wasm_bindgen(js_name = unverify)]
+    pub fn unverify(&self) -> KeyFrag {
+        KeyFrag(self.0.clone().unverify())
     }
 
     #[wasm_bindgen(js_name = toBytes)]

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -568,6 +568,6 @@ pub fn generate_kfrags(
 
 #[wasm_bindgen]
 pub fn reencrypt(capsule: &Capsule, kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
-    let backend_cfrag = umbral_pre::reencrypt(&capsule.0, &kfrag.0);
+    let backend_cfrag = umbral_pre::reencrypt(&capsule.0, kfrag.0.clone());
     VerifiedCapsuleFrag(backend_cfrag)
 }

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -420,6 +420,7 @@ impl KeyFrag {
     #[wasm_bindgen]
     pub fn verify(&self, verifying_pk: &PublicKey) -> Result<VerifiedKeyFrag, JsValue> {
         self.0
+            .clone()
             .verify(&verifying_pk.0, None, None)
             .map(VerifiedKeyFrag)
             .map_err(map_js_err)
@@ -434,6 +435,7 @@ impl KeyFrag {
         let backend_delegating_pk = delegating_pk.0;
 
         self.0
+            .clone()
             .verify(&verifying_pk.0, Some(&backend_delegating_pk), None)
             .map(VerifiedKeyFrag)
             .map_err(map_js_err)
@@ -448,6 +450,7 @@ impl KeyFrag {
         let backend_receiving_pk = receiving_pk.0;
 
         self.0
+            .clone()
             .verify(&verifying_pk.0, None, Some(&backend_receiving_pk))
             .map(VerifiedKeyFrag)
             .map_err(map_js_err)
@@ -464,6 +467,7 @@ impl KeyFrag {
         let backend_receiving_pk = receiving_pk.0;
 
         self.0
+            .clone()
             .verify(
                 &verifying_pk.0,
                 Some(&backend_delegating_pk),

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -151,7 +151,7 @@ pub struct Signer(umbral_pre::Signer);
 impl Signer {
     #[wasm_bindgen(constructor)]
     pub fn new(secret_key: &SecretKey) -> Self {
-        Self(umbral_pre::Signer::new(&secret_key.0))
+        Self(umbral_pre::Signer::new(secret_key.0.clone()))
     }
 
     pub fn sign(&self, message: &[u8]) -> Signature {

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -265,7 +265,7 @@ impl CapsuleFrag {
                 &receiving_pk.0,
             )
             .map(VerifiedCapsuleFrag)
-            .map_err(map_js_err)
+            .map_err(|(err, _cfrag)| map_js_err(err))
     }
 
     #[wasm_bindgen(js_name = skipVerification)]
@@ -423,7 +423,7 @@ impl KeyFrag {
             .clone()
             .verify(&verifying_pk.0, None, None)
             .map(VerifiedKeyFrag)
-            .map_err(map_js_err)
+            .map_err(|(err, _kfrag)| map_js_err(err))
     }
 
     #[wasm_bindgen(js_name = verifyWithDelegatingKey)]
@@ -438,7 +438,7 @@ impl KeyFrag {
             .clone()
             .verify(&verifying_pk.0, Some(&backend_delegating_pk), None)
             .map(VerifiedKeyFrag)
-            .map_err(map_js_err)
+            .map_err(|(err, _kfrag)| map_js_err(err))
     }
 
     #[wasm_bindgen(js_name = verifyWithReceivingKey)]
@@ -453,7 +453,7 @@ impl KeyFrag {
             .clone()
             .verify(&verifying_pk.0, None, Some(&backend_receiving_pk))
             .map(VerifiedKeyFrag)
-            .map_err(map_js_err)
+            .map_err(|(err, _kfrag)| map_js_err(err))
     }
 
     #[wasm_bindgen(js_name = verifyWithDelegatingAndReceivingKeys)]
@@ -474,7 +474,7 @@ impl KeyFrag {
                 Some(&backend_receiving_pk),
             )
             .map(VerifiedKeyFrag)
-            .map_err(map_js_err)
+            .map_err(|(err, _kfrag)| map_js_err(err))
     }
 
     #[wasm_bindgen(js_name = skipVerification)]

--- a/umbral-pre/bench/bench.rs
+++ b/umbral-pre/bench/bench.rs
@@ -45,8 +45,7 @@ fn bench_capsule_open_reencrypted<'a, M: Measurement>(group: &mut BenchmarkGroup
     let delegating_sk = SecretKey::random();
     let delegating_pk = delegating_sk.public_key();
 
-    let signing_sk = SecretKey::random();
-    let signer = Signer::new(&signing_sk);
+    let signer = Signer::new(SecretKey::random());
 
     let receiving_sk = SecretKey::random();
     let receiving_pk = receiving_sk.public_key();
@@ -104,8 +103,7 @@ fn bench_pre<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
     let threshold: usize = 2;
     let num_frags: usize = threshold + 1;
 
-    let signing_sk = SecretKey::random();
-    let signer = Signer::new(&signing_sk);
+    let signer = Signer::new(SecretKey::random());
 
     let receiving_sk = SecretKey::random();
     let receiving_pk = receiving_sk.public_key();

--- a/umbral-pre/bench/bench.rs
+++ b/umbral-pre/bench/bench.rs
@@ -67,7 +67,7 @@ fn bench_capsule_open_reencrypted<'a, M: Measurement>(group: &mut BenchmarkGroup
 
     let vcfrags: Vec<_> = kfrags
         .iter()
-        .map(|kfrag| reencrypt(&capsule, &kfrag))
+        .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
         .collect();
 
     let cfrags: Vec<_> = vcfrags[0..threshold]
@@ -134,15 +134,18 @@ fn bench_pre<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
         true,
     );
 
-    let vkfrag = verified_kfrags[0].clone();
+    let vkfrag = &verified_kfrags[0];
 
-    group.bench_function("reencrypt", |b| b.iter(|| reencrypt(&capsule, &vkfrag)));
+    group.bench_function("reencrypt", |b| {
+        b.iter(|| reencrypt(&capsule, vkfrag.clone()))
+    });
 
     // Decryption of the reencrypted data
 
     let verified_cfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags[0..threshold]
         .iter()
-        .map(|vkfrag| reencrypt(&capsule, &vkfrag))
+        .cloned()
+        .map(|vkfrag| reencrypt(&capsule, vkfrag))
         .collect();
 
     group.bench_function("decrypt_reencrypted", |b| {

--- a/umbral-pre/bench/bench.rs
+++ b/umbral-pre/bench/bench.rs
@@ -72,7 +72,8 @@ fn bench_capsule_open_reencrypted<'a, M: Measurement>(group: &mut BenchmarkGroup
 
     let cfrags: Vec<_> = vcfrags[0..threshold]
         .iter()
-        .map(|vcfrag| vcfrag.to_unverified())
+        .cloned()
+        .map(|vcfrag| vcfrag.unverify())
         .collect();
 
     group.bench_function("Capsule::open_reencrypted", |b| {
@@ -154,7 +155,7 @@ fn bench_pre<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
                 &receiving_sk,
                 &delegating_pk,
                 &capsule,
-                &verified_cfrags,
+                verified_cfrags.clone(),
                 &ciphertext,
             )
         })

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -294,7 +294,7 @@ impl Signer {
     #[new]
     pub fn new(sk: &SecretKey) -> Self {
         Self {
-            backend: umbral_pre::Signer::new(&sk.backend),
+            backend: umbral_pre::Signer::new(sk.backend.clone()),
         }
     }
 

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -485,7 +485,7 @@ impl KeyFrag {
                 delegating_pk.map(|pk| &pk.backend),
                 receiving_pk.map(|pk| &pk.backend),
             )
-            .map_err(|err| VerificationError::new_err(format!("{}", err)))
+            .map_err(|(err, _kfrag)| VerificationError::new_err(format!("{}", err)))
             .map(|backend_vkfrag| VerifiedKeyFrag {
                 backend: backend_vkfrag,
             })
@@ -642,7 +642,7 @@ impl CapsuleFrag {
                 &delegating_pk.backend,
                 &receiving_pk.backend,
             )
-            .map_err(|err| VerificationError::new_err(format!("{}", err)))
+            .map_err(|(err, _cfrag)| VerificationError::new_err(format!("{}", err)))
             .map(|backend_vcfrag| VerifiedCapsuleFrag {
                 backend: backend_vcfrag,
             })

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -479,6 +479,7 @@ impl KeyFrag {
         receiving_pk: Option<&PublicKey>,
     ) -> PyResult<VerifiedKeyFrag> {
         self.backend
+            .clone()
             .verify(
                 &verifying_pk.backend,
                 delegating_pk.map(|pk| &pk.backend),

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -634,6 +634,7 @@ impl CapsuleFrag {
         receiving_pk: &PublicKey,
     ) -> PyResult<VerifiedCapsuleFrag> {
         self.backend
+            .clone()
             .verify(
                 &capsule.backend,
                 &verifying_pk.backend,

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -552,9 +552,9 @@ impl VerifiedKeyFrag {
         umbral_pre::VerifiedKeyFrag::serialized_size()
     }
 
-    pub fn to_unverified(&self) -> KeyFrag {
+    pub fn unverify(&self) -> KeyFrag {
         KeyFrag {
-            backend: self.backend.to_unverified(),
+            backend: self.backend.clone().unverify(),
         }
     }
 
@@ -724,9 +724,9 @@ impl VerifiedCapsuleFrag {
         umbral_pre::VerifiedCapsuleFrag::serialized_size()
     }
 
-    pub fn to_unverified(&self) -> CapsuleFrag {
+    pub fn unverify(&self) -> CapsuleFrag {
         CapsuleFrag {
-            backend: self.backend.to_unverified(),
+            backend: self.backend.clone().unverify(),
         }
     }
 
@@ -761,7 +761,7 @@ pub fn decrypt_reencrypted(
         &receiving_sk.backend,
         &delegating_pk.backend,
         &capsule.backend,
-        &backend_cfrags,
+        backend_cfrags,
         ciphertext,
     )
     .map(|plaintext| PyBytes::new(py, &plaintext).into())

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -737,7 +737,7 @@ impl VerifiedCapsuleFrag {
 
 #[pyfunction]
 pub fn reencrypt(capsule: &Capsule, kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
-    let backend_vcfrag = umbral_pre::reencrypt(&capsule.backend, &kfrag.backend);
+    let backend_vcfrag = umbral_pre::reencrypt(&capsule.backend, kfrag.backend.clone());
     VerifiedCapsuleFrag {
         backend: backend_vcfrag,
     }

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -305,10 +305,7 @@ mod tests {
             .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
             .collect();
 
-        let cfrags: Vec<_> = vcfrags
-            .iter()
-            .map(|vcfrag| vcfrag.to_unverified())
-            .collect();
+        let cfrags = [vcfrags[0].clone().unverify(), vcfrags[1].clone().unverify()];
 
         let key_seed_reenc = capsule
             .open_reencrypted(&receiving_sk, &delegating_pk, &cfrags)
@@ -330,12 +327,10 @@ mod tests {
             .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
             .collect();
 
-        let mismatched_cfrags: Vec<_> = vcfrags[0..1]
-            .iter()
-            .cloned()
-            .chain(vcfrags2[1..2].iter().cloned())
-            .map(|vcfrag| vcfrag.to_unverified())
-            .collect();
+        let mismatched_cfrags = [
+            vcfrags[0].clone().unverify(),
+            vcfrags2[1].clone().unverify(),
+        ];
 
         let result = capsule.open_reencrypted(&receiving_sk, &delegating_pk, &mismatched_cfrags);
         assert_eq!(

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -302,7 +302,7 @@ mod tests {
 
         let vcfrags: Vec<_> = kfrags
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag))
+            .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
             .collect();
 
         let cfrags: Vec<_> = vcfrags
@@ -327,7 +327,7 @@ mod tests {
 
         let vcfrags2: Vec<_> = kfrags2
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag))
+            .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
             .collect();
 
         let mismatched_cfrags: Vec<_> = vcfrags[0..1]

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -291,8 +291,7 @@ mod tests {
         let delegating_sk = SecretKey::random();
         let delegating_pk = delegating_sk.public_key();
 
-        let signing_sk = SecretKey::random();
-        let signer = Signer::new(&signing_sk);
+        let signer = Signer::new(SecretKey::random());
 
         let receiving_sk = SecretKey::random();
         let receiving_pk = receiving_sk.public_key();

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -396,9 +396,8 @@ mod tests {
         let delegating_sk = SecretKey::random();
         let delegating_pk = delegating_sk.public_key();
 
-        let signing_sk = SecretKey::random();
-        let signer = Signer::new(&signing_sk);
-        let verifying_pk = signing_sk.public_key();
+        let signer = Signer::new(SecretKey::random());
+        let verifying_pk = signer.verifying_key();
 
         let receiving_sk = SecretKey::random();
         let receiving_pk = receiving_sk.public_key();

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -244,7 +244,7 @@ impl CapsuleFrag {
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
         receiving_pk: &PublicKey,
-    ) -> Result<VerifiedCapsuleFrag, CapsuleFragVerificationError> {
+    ) -> Result<VerifiedCapsuleFrag, (CapsuleFragVerificationError, Self)> {
         let params = capsule.params;
 
         // Here are the formulaic constituents shared with
@@ -281,7 +281,10 @@ impl CapsuleFrag {
             )
             .as_ref(),
         ) {
-            return Err(CapsuleFragVerificationError::IncorrectKeyFragSignature);
+            return Err((
+                CapsuleFragVerificationError::IncorrectKeyFragSignature,
+                self,
+            ));
         }
 
         // TODO (#46): if one or more of the values here are incorrect,
@@ -293,7 +296,7 @@ impl CapsuleFrag {
         let correct_rk_commitment = &u * &z == &u2 + &(&u1 * &h);
 
         if !(correct_reencryption_of_e & correct_reencryption_of_v & correct_rk_commitment) {
-            return Err(CapsuleFragVerificationError::IncorrectReencryption);
+            return Err((CapsuleFragVerificationError::IncorrectReencryption, self));
         }
 
         Ok(VerifiedCapsuleFrag { cfrag: self })

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -78,7 +78,7 @@ impl CapsuleFragProof {
     fn from_kfrag_and_cfrag(
         rng: &mut (impl CryptoRng + RngCore),
         capsule: &Capsule,
-        kfrag: &KeyFrag,
+        kfrag: KeyFrag,
         cfrag_e1: &CurvePoint,
         cfrag_v1: &CurvePoint,
     ) -> Self {
@@ -114,7 +114,7 @@ impl CapsuleFragProof {
             kfrag_commitment: u1,
             kfrag_pok: u2,
             signature: z3,
-            kfrag_signature: kfrag.proof.signature_for_receiver(),
+            kfrag_signature: kfrag.proof.signature_for_receiver,
         }
     }
 }
@@ -217,18 +217,20 @@ impl CapsuleFrag {
     fn reencrypted(
         rng: &mut (impl CryptoRng + RngCore),
         capsule: &Capsule,
-        kfrag: &KeyFrag,
+        kfrag: KeyFrag,
     ) -> Self {
         let rk = kfrag.key;
         let e1 = &capsule.point_e * &rk;
         let v1 = &capsule.point_v * &rk;
+        let id = kfrag.id;
+        let precursor = kfrag.precursor;
         let proof = CapsuleFragProof::from_kfrag_and_cfrag(rng, capsule, kfrag, &e1, &v1);
 
         Self {
             point_e1: e1,
             point_v1: v1,
-            kfrag_id: kfrag.id,
-            precursor: kfrag.precursor,
+            kfrag_id: id,
+            precursor,
             proof,
         }
     }
@@ -340,7 +342,7 @@ impl VerifiedCapsuleFrag {
     pub(crate) fn reencrypted(
         rng: &mut (impl CryptoRng + RngCore),
         capsule: &Capsule,
-        kfrag: &KeyFrag,
+        kfrag: KeyFrag,
     ) -> Self {
         VerifiedCapsuleFrag {
             cfrag: CapsuleFrag::reencrypted(rng, capsule, kfrag),
@@ -407,7 +409,7 @@ mod tests {
 
         let verified_cfrags: Vec<_> = kfrags
             .iter()
-            .map(|kfrag| reencrypt(&capsule, &kfrag))
+            .map(|kfrag| reencrypt(&capsule, kfrag.clone()))
             .collect();
 
         (

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -237,7 +237,7 @@ impl CapsuleFrag {
     /// the encrypting party's key, the decrypting party's key, and the signing key.
     #[allow(clippy::many_single_char_names)]
     pub fn verify(
-        &self,
+        self,
         capsule: &Capsule,
         verifying_pk: &PublicKey,
         delegating_pk: &PublicKey,
@@ -294,9 +294,7 @@ impl CapsuleFrag {
             return Err(CapsuleFragVerificationError::IncorrectReencryption);
         }
 
-        Ok(VerifiedCapsuleFrag {
-            cfrag: self.clone(),
-        })
+        Ok(VerifiedCapsuleFrag { cfrag: self })
     }
 
     /// Explicitly skips verification.

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -362,8 +362,8 @@ impl VerifiedCapsuleFrag {
     /// Useful for the cases where it needs to be put in the protocol structure
     /// containing [`CapsuleFrag`] types (since those are the ones
     /// that can be serialized/deserialized freely).
-    pub fn to_unverified(&self) -> CapsuleFrag {
-        self.cfrag.clone()
+    pub fn unverify(self) -> CapsuleFrag {
+        self.cfrag
     }
 }
 

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -64,7 +64,7 @@ impl DeserializableFromArray for KeyFragID {
 pub(crate) struct KeyFragProof {
     pub(crate) commitment: CurvePoint,
     signature_for_proxy: Signature,
-    signature_for_receiver: Signature,
+    pub(crate) signature_for_receiver: Signature,
     delegating_key_signed: bool,
     receiving_key_signed: bool,
 }
@@ -160,10 +160,6 @@ impl KeyFragProof {
             delegating_key_signed: sign_delegating_key,
             receiving_key_signed: sign_receiving_key,
         }
-    }
-
-    pub(crate) fn signature_for_receiver(&self) -> Signature {
-        self.signature_for_receiver.clone()
     }
 }
 

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -425,8 +425,8 @@ impl VerifiedKeyFrag {
     /// Useful for the cases where it needs to be put in the protocol structure
     /// containing [`KeyFrag`] types (since those are the ones
     /// that can be serialized/deserialized freely).
-    pub fn to_unverified(&self) -> KeyFrag {
-        self.kfrag.clone()
+    pub fn unverify(self) -> KeyFrag {
+        self.kfrag
     }
 }
 

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -118,7 +118,7 @@ fn none_unless<T>(x: Option<T>, predicate: bool) -> Option<T> {
 impl KeyFragProof {
     fn from_base(
         rng: &mut (impl CryptoRng + RngCore),
-        base: &KeyFragBase,
+        base: &KeyFragBase<'_>,
         kfrag_id: &KeyFragID,
         kfrag_key: &CurveScalar,
         sign_delegating_key: bool,
@@ -267,7 +267,7 @@ impl fmt::Display for KeyFragVerificationError {
 impl KeyFrag {
     fn from_base(
         rng: &mut (impl CryptoRng + RngCore),
-        base: &KeyFragBase,
+        base: &KeyFragBase<'_>,
         sign_delegating_key: bool,
         sign_receiving_key: bool,
     ) -> Self {
@@ -401,7 +401,7 @@ impl fmt::Display for VerifiedKeyFrag {
 impl VerifiedKeyFrag {
     pub(crate) fn from_base(
         rng: &mut (impl CryptoRng + RngCore),
-        base: &KeyFragBase,
+        base: &KeyFragBase<'_>,
         sign_delegating_key: bool,
         sign_receiving_key: bool,
     ) -> Self {
@@ -428,8 +428,8 @@ impl VerifiedKeyFrag {
     }
 }
 
-pub(crate) struct KeyFragBase {
-    signer: Signer,
+pub(crate) struct KeyFragBase<'a> {
+    signer: &'a Signer,
     precursor: CurvePoint,
     dh_point: CurvePoint,
     params: Parameters,
@@ -438,12 +438,12 @@ pub(crate) struct KeyFragBase {
     coefficients: Box<[SecretBox<NonZeroCurveScalar>]>,
 }
 
-impl KeyFragBase {
+impl<'a> KeyFragBase<'a> {
     pub fn new(
         rng: &mut (impl CryptoRng + RngCore),
         delegating_sk: &SecretKey,
         receiving_pk: &PublicKey,
-        signer: &Signer,
+        signer: &'a Signer,
         threshold: usize,
     ) -> Self {
         let g = CurvePoint::generator();
@@ -474,7 +474,7 @@ impl KeyFragBase {
         }
 
         Self {
-            signer: signer.clone(),
+            signer,
             precursor,
             dh_point,
             params,

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -528,9 +528,8 @@ mod tests {
         let delegating_sk = SecretKey::random();
         let delegating_pk = delegating_sk.public_key();
 
-        let signing_sk = SecretKey::random();
-        let signer = Signer::new(&signing_sk);
-        let verifying_pk = signing_sk.public_key();
+        let signer = Signer::new(SecretKey::random());
+        let verifying_pk = signer.verifying_key();
 
         let receiving_sk = SecretKey::random();
         let receiving_pk = receiving_sk.public_key();

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -313,7 +313,7 @@ impl KeyFrag {
     /// for `sign_delegating_key` or `sign_receiving_key`, and the respective key
     /// is not provided, the verification fails.
     pub fn verify(
-        &self,
+        self,
         verifying_pk: &PublicKey,
         maybe_delegating_pk: Option<&PublicKey>,
         maybe_receiving_pk: Option<&PublicKey>,
@@ -356,9 +356,7 @@ impl KeyFrag {
             return Err(KeyFragVerificationError::IncorrectSignature);
         }
 
-        Ok(VerifiedKeyFrag {
-            kfrag: self.clone(),
-        })
+        Ok(VerifiedKeyFrag { kfrag: self })
     }
 
     /// Explicitly skips verification.
@@ -561,7 +559,7 @@ mod tests {
                             None
                         };
                         let maybe_rk = if supply_rk { Some(&receiving_pk) } else { None };
-                        let res = kfrag.verify(&verifying_pk, maybe_dk, maybe_rk);
+                        let res = kfrag.clone().verify(&verifying_pk, maybe_dk, maybe_rk);
 
                         let sufficient_dk = !sign_dk || (supply_dk == sign_dk);
                         let sufficient_rk = !sign_rk || (supply_rk == sign_rk);

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -173,22 +173,20 @@ fn digest_for_signing(message: &[u8]) -> BackendDigest {
 
 /// An object used to sign messages.
 /// For security reasons cannot be serialized.
+// `k256::SigningKey` is zeroized on `Drop` as of `k256=0.10`.
 #[derive(Clone)]
-pub struct Signer(SecretKey);
+pub struct Signer(SigningKey::<CurveType>);
 
 impl Signer {
     /// Creates a new signer out of a secret key.
     pub fn new(sk: SecretKey) -> Self {
-        Self(sk)
+        Self(SigningKey::<CurveType>::from(sk.0))
     }
 
     /// Signs the given message using the given RNG.
     pub fn sign_with_rng(&self, rng: &mut (impl CryptoRng + RngCore), message: &[u8]) -> Signature {
         let digest = digest_for_signing(message);
-        let secret_key = self.0.clone();
-        // `k256::SigningKey` is zeroized on `Drop` as of `k256=0.10`.
-        let signing_key = SigningKey::<CurveType>::from(secret_key.0);
-        Signature(signing_key.sign_digest_with_rng(rng, digest))
+        Signature(self.0.sign_digest_with_rng(rng, digest))
     }
 
     /// Signs the given message using the default RNG.
@@ -200,7 +198,7 @@ impl Signer {
 
     /// Returns the public key that can be used to verify the signatures produced by this signer.
     pub fn verifying_key(&self) -> PublicKey {
-        self.0.public_key()
+        PublicKey(self.0.verifying_key().into())
     }
 }
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -178,8 +178,8 @@ pub struct Signer(SecretKey);
 
 impl Signer {
     /// Creates a new signer out of a secret key.
-    pub fn new(sk: &SecretKey) -> Self {
-        Self(sk.clone())
+    pub fn new(sk: SecretKey) -> Self {
+        Self(sk)
     }
 
     /// Signs the given message using the given RNG.
@@ -450,7 +450,7 @@ mod tests {
     fn test_sign_and_verify() {
         let sk = SecretKey::random();
         let message = b"asdafdahsfdasdfasd";
-        let signer = Signer::new(&sk);
+        let signer = Signer::new(sk.clone());
         let signature = signer.sign(message);
 
         let pk = sk.public_key();
@@ -463,10 +463,9 @@ mod tests {
     #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde_serialization() {
-        let sk = SecretKey::random();
-        let pk = sk.public_key();
         let message = b"asdafdahsfdasdfasd";
-        let signer = Signer::new(&sk);
+        let signer = Signer::new(SecretKey::random());
+        let pk = signer.verifying_key();
         let signature = signer.sign(message);
 
         check_serialization(&pk, Representation::Hex);

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -175,7 +175,7 @@ fn digest_for_signing(message: &[u8]) -> BackendDigest {
 /// For security reasons cannot be serialized.
 // `k256::SigningKey` is zeroized on `Drop` as of `k256=0.10`.
 #[derive(Clone)]
-pub struct Signer(SigningKey::<CurveType>);
+pub struct Signer(SigningKey<CurveType>);
 
 impl Signer {
     /// Creates a new signer out of a secret key.

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -27,9 +27,8 @@
 //! // Key Generation (on Alice's side)
 //! let alice_sk = SecretKey::random();
 //! let alice_pk = alice_sk.public_key();
-//! let signing_sk = SecretKey::random();
-//! let signer = Signer::new(&signing_sk);
-//! let verifying_pk = signing_sk.public_key();
+//! let signer = Signer::new(SecretKey::random());
+//! let verifying_pk = signer.verifying_key();
 //!
 //! // Key Generation (on Bob's side)
 //! let bob_sk = SecretKey::random();

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -71,11 +71,11 @@
 //!
 //! // Ursula 0
 //! let verified_kfrag0 = kfrag0.verify(&verifying_pk, Some(&alice_pk), Some(&bob_pk)).unwrap();
-//! let verified_cfrag0 = reencrypt(&capsule, &verified_kfrag0);
+//! let verified_cfrag0 = reencrypt(&capsule, verified_kfrag0);
 //!
 //! // Ursula 1
 //! let verified_kfrag1 = kfrag1.verify(&verifying_pk, Some(&alice_pk), Some(&bob_pk)).unwrap();
-//! let verified_cfrag1 = reencrypt(&capsule, &verified_kfrag1);
+//! let verified_cfrag1 = reencrypt(&capsule, verified_kfrag1);
 //!
 //! // ...
 //!

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -95,7 +95,7 @@
 //!     .unwrap();
 //!
 //! let plaintext_bob = decrypt_reencrypted(
-//!     &bob_sk, &alice_pk, &capsule, &[verified_cfrag0, verified_cfrag1], &ciphertext).unwrap();
+//!     &bob_sk, &alice_pk, &capsule, [verified_cfrag0, verified_cfrag1], &ciphertext).unwrap();
 //! assert_eq!(&plaintext_bob as &[u8], plaintext);
 //! ```
 //!

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -278,7 +278,7 @@ mod tests {
 
         // If Bob received cfrags from the network, he must check that they are valid
         let verified_cfrags: Vec<_> = cfrags
-            .iter()
+            .into_iter()
             .map(|cfrag| {
                 cfrag
                     .verify(&capsule, &verifying_pk, &delegating_pk, &receiving_pk)

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -256,7 +256,7 @@ mod tests {
 
         // If Ursula received kfrags from the network, she must check that they are valid
         let verified_kfrags: Vec<_> = kfrags
-            .iter()
+            .into_iter()
             .map(|kfrag| {
                 kfrag
                     .verify(&verifying_pk, Some(&delegating_pk), Some(&receiving_pk))

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -148,16 +148,16 @@ pub fn generate_kfrags(
 pub fn reencrypt_with_rng(
     rng: &mut (impl CryptoRng + RngCore),
     capsule: &Capsule,
-    verified_kfrag: &VerifiedKeyFrag,
+    verified_kfrag: VerifiedKeyFrag,
 ) -> VerifiedCapsuleFrag {
     let kfrag = verified_kfrag.to_unverified();
-    VerifiedCapsuleFrag::reencrypted(rng, capsule, &kfrag)
+    VerifiedCapsuleFrag::reencrypted(rng, capsule, kfrag)
 }
 
 /// A synonym for [`reencrypt_with_rng`] with the default RNG.
 #[cfg(feature = "default-rng")]
 #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
-pub fn reencrypt(capsule: &Capsule, verified_kfrag: &VerifiedKeyFrag) -> VerifiedCapsuleFrag {
+pub fn reencrypt(capsule: &Capsule, verified_kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag {
     reencrypt_with_rng(&mut OsRng, capsule, verified_kfrag)
 }
 
@@ -267,7 +267,7 @@ mod tests {
 
         let verified_cfrags: Vec<VerifiedCapsuleFrag> = verified_kfrags[0..threshold]
             .iter()
-            .map(|vkfrag| reencrypt(&capsule, &vkfrag))
+            .map(|vkfrag| reencrypt(&capsule, vkfrag.clone()))
             .collect();
 
         // Simulate network transfer

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -221,9 +221,8 @@ mod tests {
         let delegating_sk = SecretKey::random();
         let delegating_pk = delegating_sk.public_key();
 
-        let signing_sk = SecretKey::random();
-        let signer = Signer::new(&signing_sk);
-        let verifying_pk = signing_sk.public_key();
+        let signer = Signer::new(SecretKey::random());
+        let verifying_pk = signer.verifying_key();
 
         // Key Generation (Bob)
         let receiving_sk = SecretKey::random();


### PR DESCRIPTION
Fixes #88

The following API changes were made:
- `Signer::new()` consumes the given `SecretKey` (fixes #61).
- `KeyFrag::verify()` and `CapsuleFrag::verify()` consume the given kfrag/cfrag.
- As a consequence, `KeyFrag::verify()` and `CapsuleFrag::verify()` return the original frag on error (as a tuple with the error itself), for logging purposes (since the original object is not available anymore).
- `reencrypt()` consumes the cfrag (but not the capsule, since it wasn't being cloned inside).
- `VerifiedKeyFrag::to_unverified()` and `VerifiedCapsuleFrag::to_unverified()` were renamed to `unverify()` and consume the corresponding frag. 