### PR TITLE
Use the standard hash2curve implementation instead of `unsafe_hash_to_point()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `KeyFrag::verify()` and `CapsuleFrag::verify()` consume the given kfrag/cfrag, `reencrypt()` consumes the cfrag (but not the capsule). ([#91])
 - As a consequence, `KeyFrag::verify()` and `CapsuleFrag::verify()` return the original frag on error (as a tuple with the error itself), for logging purposes (since the original object is not available anymore). ([#91])
 - `VerifiedKeyFrag::to_unverified()` and `VerifiedCapsuleFrag::to_unverified()` were renamed to `unverify()` and consume the corresponding frag. ([#91])
+- Using the [IETF standard](https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/) to hash to point instead of a custom implementation (and bumps `k256` to 0.10.2). Changes the format of all the library's objects! ([#92])
 
 
 ### Fixed
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#87]: https://github.com/nucypher/rust-umbral/pull/87
 [#91]: https://github.com/nucypher/rust-umbral/pull/91
+[#92]: https://github.com/nucypher/rust-umbral/pull/92
 
 
 ## [0.4.0] - 2021-12-24

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unused_unit)] // Temporarily silence the warnings introduced in wasm-bindgen 0.2.79
 #![no_std]
 
 // Use `wee_alloc` as the global allocator.

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.10.1", default-features = false, features = ["ecdsa", "arithmetic"] }
+k256 = { version = "0.10.2", default-features = false, features = ["ecdsa", "arithmetic", "hash2curve"] }
 sha2 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.9" }
 hkdf = { version = "0.11", default-features = false }

--- a/umbral-pre/bench/bench.rs
+++ b/umbral-pre/bench/bench.rs
@@ -2,23 +2,12 @@ use criterion::measurement::Measurement;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 
 #[cfg(feature = "bench-internals")]
-use umbral_pre::bench::{
-    capsule_from_public_key, capsule_open_original, capsule_open_reencrypted, unsafe_hash_to_point,
-};
+use umbral_pre::bench::{capsule_from_public_key, capsule_open_original, capsule_open_reencrypted};
 
 use umbral_pre::{
     decrypt_original, decrypt_reencrypted, encrypt, generate_kfrags, reencrypt, SecretKey, Signer,
     VerifiedCapsuleFrag,
 };
-
-#[cfg(feature = "bench-internals")]
-fn bench_unsafe_hash_to_point<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
-    let data = b"abcdefg";
-    let label = b"sdasdasd";
-    group.bench_function("unsafe_hash_to_point", |b| {
-        b.iter(|| unsafe_hash_to_point(&data[..], &label[..]))
-    });
-}
 
 #[cfg(feature = "bench-internals")]
 fn bench_capsule_from_public_key<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
@@ -165,7 +154,6 @@ fn bench_pre<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
 #[cfg(feature = "bench-internals")]
 fn group_internals(c: &mut Criterion) {
     let mut group = c.benchmark_group("internals");
-    bench_unsafe_hash_to_point(&mut group);
     bench_capsule_from_public_key(&mut group);
     bench_capsule_open_original(&mut group);
     bench_capsule_open_reencrypted(&mut group);

--- a/umbral-pre/src/bench.rs
+++ b/umbral-pre/src/bench.rs
@@ -9,8 +9,6 @@ use crate::capsule_frag::CapsuleFrag;
 use crate::keys::{PublicKey, SecretKey};
 use crate::secret_box::SecretBox;
 
-pub use crate::hashing::unsafe_hash_to_point;
-
 /// Exported `Capsule::from_public_key()` for benchmark purposes.
 pub fn capsule_from_public_key(delegating_pk: &PublicKey) -> (Capsule, SecretBox<KeySeed>) {
     Capsule::from_public_key(&mut OsRng, delegating_pk)

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -8,13 +8,15 @@ use core::ops::{Add, Mul, Sub};
 use digest::Digest;
 use elliptic_curve::bigint::U256; // Note that this type is different from typenum::U256
 use elliptic_curve::group::ff::PrimeField;
+use elliptic_curve::hash2curve::GroupDigest;
+use elliptic_curve::hash2field::ExpandMsgXmd;
 use elliptic_curve::ops::Reduce;
 use elliptic_curve::sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint};
-use elliptic_curve::Field;
-use elliptic_curve::{AffinePoint, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};
+use elliptic_curve::{AffinePoint, Field, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};
 use generic_array::GenericArray;
 use k256::Secp256k1;
 use rand_core::{CryptoRng, RngCore};
+use sha2::Sha256;
 use subtle::CtOption;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
@@ -160,11 +162,11 @@ impl CurvePoint {
     }
 
     pub(crate) fn generator() -> Self {
-        Self(BackendPoint::generator())
+        Self(BackendPoint::GENERATOR)
     }
 
     pub(crate) fn identity() -> Self {
-        Self(BackendPoint::identity())
+        Self(BackendPoint::IDENTITY)
     }
 
     pub(crate) fn to_affine_point(self) -> BackendPointAffine {
@@ -184,6 +186,15 @@ impl CurvePoint {
         *GenericArray::<u8, CompressedPointSize>::from_slice(
             self.0.to_affine().to_encoded_point(true).as_bytes(),
         )
+    }
+
+    /// Hashes arbitrary data with the given domain separation tag
+    /// into a valid EC point of the specified curve, using the algorithm described in the
+    /// [IETF hash-to-curve standard](https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/)
+    pub(crate) fn from_data(dst: &[u8], data: &[u8]) -> Option<Self> {
+        Some(Self(
+            CurveType::hash_from_bytes::<ExpandMsgXmd<Sha256>>(&[data], dst).ok()?,
+        ))
     }
 }
 

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -1,65 +1,15 @@
 use digest::Digest;
-use generic_array::sequence::Concat;
-use generic_array::GenericArray;
 use sha2::Sha256;
-use typenum::U1;
 
 use crate::curve::{CurvePoint, NonZeroCurveScalar};
 use crate::secret_box::{CanBeZeroizedOnDrop, SecretBox};
 use crate::traits::SerializableToArray;
-
-/// Hashes arbitrary data with the given domain separation tag
-/// into a valid EC point of the specified curve,
-/// using the try-and-increment method.
-///
-/// WARNING: Do not use when the input data is secret, as this implementation is not
-/// in constant time, and hence, it is not safe with respect to timing attacks.
-pub fn unsafe_hash_to_point(dst: &[u8], data: &[u8]) -> Option<CurvePoint> {
-    // NOTE: Yes, this function is hacky, but it is the only way
-    // to hash to a point with an *unknown* discrete log.
-    // Don't replace with hashing to scalar and multiplying by a generator!
-
-    // TODO (#35): use the standard method when it is available in RustCrypto.
-
-    // Fixed sign prefix. Halves the range of the generated points, but we only need one,
-    // and it is always the same.
-    let sign_prefix = GenericArray::<u8, U1>::from_slice(&[2u8]);
-
-    let data_len = (data.len() as u32).to_be_bytes();
-
-    // We use an internal 32-bit counter as additional input
-    let mut i = 0u32;
-    while i < <u32>::MAX {
-        let result = BytesDigest::new_with_dst(dst)
-            .chain_bytes(&data_len)
-            .chain_bytes(data)
-            .chain_bytes(&i.to_be_bytes())
-            .finalize();
-
-        // Set the sign byte
-        let maybe_point_bytes = sign_prefix.concat(result);
-
-        let maybe_point = CurvePoint::from_compressed_array(&maybe_point_bytes);
-        if let Some(point) = maybe_point {
-            return Some(point);
-        }
-
-        i += 1
-    }
-
-    // Each iteration can fail with probability 2^(-32), so we probably never reach this point.
-    // And even if we do, it's only called once in Parameters::new(), and is easy to notice.
-    None
-}
 
 // Our hash of choice.
 pub(crate) type BackendDigest = Sha256;
 
 // Wraps BackendDigest for easier replacement, and standardizes the use of DST.
 pub(crate) struct Hash(BackendDigest);
-
-// Can't be put in the `impl` in the current version of Rust.
-pub type HashOutputSize = <BackendDigest as Digest>::OutputSize;
 
 impl Hash {
     pub fn new() -> Self {
@@ -123,45 +73,11 @@ impl ScalarDigest {
     }
 }
 
-pub(crate) struct BytesDigest(Hash);
-
-impl BytesDigest {
-    pub fn new_with_dst(dst: &[u8]) -> Self {
-        Self(Hash::new_with_dst(dst))
-    }
-
-    pub fn chain_bytes<T: AsRef<[u8]>>(self, bytes: T) -> Self {
-        Self(self.0.chain_bytes(bytes))
-    }
-
-    pub fn finalize(self) -> GenericArray<u8, HashOutputSize> {
-        self.0.digest().finalize()
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
-    use super::{unsafe_hash_to_point, BytesDigest, HashOutputSize, ScalarDigest};
+    use super::ScalarDigest;
     use crate::curve::{CurvePoint, CurveScalar};
-    use generic_array::GenericArray;
-
-    #[test]
-    fn test_unsafe_hash_to_point() {
-        let data = b"abcdefg";
-        let dst = b"sdasdasd";
-        let p: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data[..]);
-        let p_same: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data[..]);
-        assert_eq!(p, p_same);
-
-        let data2 = b"abcdefgh";
-        let p_data2: Option<CurvePoint> = unsafe_hash_to_point(&dst[..], &data2[..]);
-        assert_ne!(p, p_data2);
-
-        let dst2 = b"sdasdasds";
-        let p_dst2: Option<CurvePoint> = unsafe_hash_to_point(&dst2[..], &data[..]);
-        assert_ne!(p, p_dst2);
-    }
 
     #[test]
     fn test_scalar_digest() {
@@ -193,30 +109,6 @@ mod tests {
             .chain_bytes(bytes)
             .finalize()
             .into();
-        assert_ne!(s, s_diff_tag);
-    }
-
-    #[test]
-    fn test_bytes_digest() {
-        let bytes: &[u8] = b"foobar";
-        let bytes2: &[u8] = b"barbaz";
-
-        let s: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
-            .chain_bytes(bytes)
-            .finalize();
-        let s_same: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
-            .chain_bytes(bytes)
-            .finalize();
-        assert_eq!(s, s_same);
-
-        let s_diff: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"abc")
-            .chain_bytes(bytes2)
-            .finalize();
-        assert_ne!(s, s_diff);
-
-        let s_diff_tag: GenericArray<u8, HashOutputSize> = BytesDigest::new_with_dst(b"def")
-            .chain_bytes(bytes)
-            .finalize();
         assert_ne!(s, s_diff_tag);
     }
 }

--- a/umbral-pre/src/params.rs
+++ b/umbral-pre/src/params.rs
@@ -1,5 +1,4 @@
 use crate::curve::CurvePoint;
-use crate::hashing::unsafe_hash_to_point;
 
 /// An object containing shared scheme parameters.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14,15 +13,9 @@ impl Parameters {
         // `g` is fixed to be the generator because it has to be the same
         // as the one used for secret/public keys, and it is standardized (for a given curve).
 
-        // Only fails with a minuscule probability,
-        // and since `g` is fixed here, we can just ignore the panic branch,
-        // because we know it succeeds.
-
-        // Technically, we don't need the DST here now since it's a custom hashing function
-        // used for exactly one purpose (and, really, on only one value).
-        // But in view of possible replacement with the standard hash-to-curve (see #35),
-        // which will need a DST, we're using a DST here as well.
-        let u = unsafe_hash_to_point(b"PARAMETERS", b"POINT_U").unwrap();
+        // Only fails when the given binary string is too large, which is not the case here,
+        // so we can safely unwrap.
+        let u = CurvePoint::from_data(b"PARAMETERS", b"POINT_U").unwrap();
 
         Self { u }
     }


### PR DESCRIPTION
Uses the upcoming functionality based on the [IETF standard](https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/) instead of our homegrown implementation.  Fixes #35