### PR TITLE
Bump crate versions

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.0 # MSRV
+        toolchain: 1.57.0 # MSRV
         components: clippy
         override: true
         profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - When serialized to a human-readable format using `serde`, hex-encoded objects now have a `0x` prefix. ([#94])
+- Bumped `k256` to 0.11, `sha2` to 0.10, `hkdf` to 0.12, `chacha20poly1305` to 0.10, and `zeroize` to 1.5 (and MSRV to 1.57), so that we could use the new `ZeroizeOnDrop` functionality. In particular, `SecretBox`, `SecretKey`, `Signer`, and `DEM` now implement `ZeroizeOnDrop`. ([#97])
+- Removed `CanBeZeroizedOnDrop` trait, since `GenericArray` now supports `Zeroize` natively. ([#97])
+- Bumped `pyo3` to 0.16. ([#97])
 
 
 ### Added
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [#94]: https://github.com/nucypher/rust-umbral/pull/94
+[#97]: https://github.com/nucypher/rust-umbral/pull/97
 
 
 ## [0.5.2] - 2022-03-15

--- a/umbral-pre-python/Cargo.toml
+++ b/umbral-pre-python/Cargo.toml
@@ -14,4 +14,4 @@ generic-array = "0.14"
 # Unfortunately, we (for the time being?) cannot use a re-exported `pyo3`
 # from the main `umbral-pre`, since `pyo3` macros and `pip` build need an explicit dependency.
 # This version has to be matched with the one in `umbral-pre`.
-pyo3 = "0.15"
+pyo3 = "0.16"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -25,15 +25,15 @@ wasm-bindgen = {version = "0.2.74", optional = true }
 # Their versions should be updated when the main packages above are updated.
 elliptic-curve = { version = "0.12" }
 digest = "0.10"
-generic-array = "0.14"
+generic-array = { version = "0.14.6", features = ["zeroize"] }
 aead = { version = "0.4", default-features = false }
-ecdsa = { version = "0.14" }
+ecdsa = { version = "0.14.4" } # Pin patch version to enable ZeroizeOnDrop for SigningKey
 signature = { version = "1.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 subtle = { version = "2.4", default-features = false }
-zeroize = "1.5"
+zeroize = { version = "1.5", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-k256 = { version = "0.10.4", default-features = false, features = ["ecdsa", "arithmetic", "hash2curve"] }
-sha2 = { version = "0.9", default-features = false }
+k256 = { version = "0.11", default-features = false, features = ["ecdsa", "arithmetic", "hash2curve"] }
+sha2 = { version = "0.10", default-features = false }
 chacha20poly1305 = { version = "0.9" }
-hkdf = { version = "0.11", default-features = false }
+hkdf = { version = "0.12", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
@@ -23,17 +23,17 @@ wasm-bindgen = {version = "0.2.74", optional = true }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
-elliptic-curve = { version = "0.11.7" }
-digest = "0.9"
+elliptic-curve = { version = "0.12" }
+digest = "0.10"
 generic-array = "0.14"
 aead = { version = "0.4", default-features = false }
-ecdsa = { version = "0.13" }
-signature = { version = "1.4", default-features = false }
+ecdsa = { version = "0.14" }
+signature = { version = "1.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
 getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 subtle = { version = "2.4", default-features = false }
-zeroize = "1.3"
+zeroize = "1.5"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -17,7 +17,7 @@ hkdf = { version = "0.12", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-pyo3 = { version = "0.15", optional = true }
+pyo3 = { version = "0.16", optional = true }
 js-sys = { version = "0.3", optional = true }
 wasm-bindgen = {version = "0.2.74", optional = true }
 

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "arithmetic", "hash2curve"] }
 sha2 = { version = "0.10", default-features = false }
-chacha20poly1305 = { version = "0.9" }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc"] }
 hkdf = { version = "0.12", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
@@ -26,7 +26,7 @@ wasm-bindgen = {version = "0.2.74", optional = true }
 elliptic-curve = { version = "0.12" }
 digest = "0.10"
 generic-array = { version = "0.14.6", features = ["zeroize"] }
-aead = { version = "0.4", default-features = false }
+aead = { version = "0.5", default-features = false }
 ecdsa = { version = "0.14.4" } # Pin patch version to enable ZeroizeOnDrop for SigningKey
 signature = { version = "1.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -15,7 +15,6 @@ use pyo3::prelude::*;
 use pyo3::pyclass::PyClass;
 use pyo3::types::{PyBytes, PyUnicode};
 use pyo3::wrap_pyfunction;
-use pyo3::PyObjectProtocol;
 
 use crate as umbral_pre;
 use crate::{
@@ -145,10 +144,7 @@ impl SecretKey {
     pub fn serialized_size() -> usize {
         umbral_pre::SecretKey::serialized_size()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for SecretKey {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }
@@ -219,10 +215,7 @@ impl SecretKeyFactory {
     pub fn serialized_size() -> usize {
         umbral_pre::SecretKeyFactory::serialized_size()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for SecretKeyFactory {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }
@@ -261,11 +254,8 @@ impl PublicKey {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for PublicKey {
-    fn __richcmp__(&self, other: PyRef<PublicKey>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, PublicKey>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -309,10 +299,7 @@ impl Signer {
             backend: self.backend.verifying_key(),
         }
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Signer {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }
@@ -355,11 +342,8 @@ impl Signature {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Signature {
-    fn __richcmp__(&self, other: PyRef<Signature>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, Signature>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -405,11 +389,8 @@ impl Capsule {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Capsule {
-    fn __richcmp__(&self, other: PyRef<Capsule>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, Capsule>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -510,11 +491,8 @@ impl KeyFrag {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for KeyFrag {
-    fn __richcmp__(&self, other: PyRef<KeyFrag>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, KeyFrag>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -562,11 +540,8 @@ impl VerifiedKeyFrag {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for VerifiedKeyFrag {
-    fn __richcmp__(&self, other: PyRef<VerifiedKeyFrag>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, VerifiedKeyFrag>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -667,11 +642,8 @@ impl CapsuleFrag {
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for CapsuleFrag {
-    fn __richcmp__(&self, other: PyRef<CapsuleFrag>, op: CompareOp) -> PyResult<bool> {
+    fn __richcmp__(&self, other: PyRef<'_, CapsuleFrag>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -696,9 +668,9 @@ impl AsBackend<umbral_pre::VerifiedCapsuleFrag> for VerifiedCapsuleFrag {
     }
 }
 
-#[pyproto]
-impl PyObjectProtocol for VerifiedCapsuleFrag {
-    fn __richcmp__(&self, other: PyRef<VerifiedCapsuleFrag>, op: CompareOp) -> PyResult<bool> {
+#[pymethods]
+impl VerifiedCapsuleFrag {
+    fn __richcmp__(&self, other: PyRef<'_, VerifiedCapsuleFrag>, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
 
@@ -709,10 +681,7 @@ impl PyObjectProtocol for VerifiedCapsuleFrag {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("{}", self.backend))
     }
-}
 
-#[pymethods]
-impl VerifiedCapsuleFrag {
     #[staticmethod]
     pub fn from_verified_bytes(data: &[u8]) -> PyResult<Self> {
         umbral_pre::VerifiedCapsuleFrag::from_verified_bytes(data)

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -315,7 +315,7 @@ mod tests {
         // Empty cfrag vector
         let result = capsule.open_reencrypted(&receiving_sk, &delegating_pk, &[]);
         assert_eq!(
-            result.map(|x| *x.as_secret()),
+            result.map(|x| x.as_secret().clone()),
             Err(OpenReencryptedError::NoCapsuleFrags)
         );
 
@@ -334,7 +334,7 @@ mod tests {
 
         let result = capsule.open_reencrypted(&receiving_sk, &delegating_pk, &mismatched_cfrags);
         assert_eq!(
-            result.map(|x| *x.as_secret()),
+            result.map(|x| x.as_secret().clone()),
             Err(OpenReencryptedError::MismatchedCapsuleFrags)
         );
 
@@ -342,7 +342,7 @@ mod tests {
         let (capsule2, _key_seed) = Capsule::from_public_key(&mut OsRng, &delegating_pk);
         let result = capsule2.open_reencrypted(&receiving_sk, &delegating_pk, &cfrags);
         assert_eq!(
-            result.map(|x| *x.as_secret()),
+            result.map(|x| x.as_secret().clone()),
             Err(OpenReencryptedError::ValidationFailed)
         );
     }

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -8,8 +8,7 @@ use core::ops::{Add, Mul, Sub};
 use digest::Digest;
 use elliptic_curve::bigint::U256; // Note that this type is different from typenum::U256
 use elliptic_curve::group::ff::PrimeField;
-use elliptic_curve::hash2curve::GroupDigest;
-use elliptic_curve::hash2field::ExpandMsgXmd;
+use elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use elliptic_curve::ops::Reduce;
 use elliptic_curve::sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint};
 use elliptic_curve::{AffinePoint, Field, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -19,7 +19,6 @@ use sha2::Sha256;
 use subtle::CtOption;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
-use crate::secret_box::CanBeZeroizedOnDrop;
 use crate::traits::{
     ConstructionError, DeserializableFromArray, HasTypeName, RepresentableAsArray,
     SerializableToArray,
@@ -30,12 +29,6 @@ type CompressedPointSize = <FieldSize<CurveType> as ModulusSize>::CompressedPoin
 
 type BackendScalar = Scalar<CurveType>;
 pub(crate) type BackendNonZeroScalar = NonZeroScalar<CurveType>;
-
-impl CanBeZeroizedOnDrop for BackendNonZeroScalar {
-    fn ensure_zeroized_on_drop(&mut self) {
-        self.zeroize()
-    }
-}
 
 // We have to define newtypes for scalar and point here because the compiler
 // is not currently smart enough to resolve `BackendScalar` and `BackendPoint`
@@ -59,12 +52,6 @@ impl CurveScalar {
 }
 
 impl DefaultIsZeroes for CurveScalar {}
-
-impl CanBeZeroizedOnDrop for CurveScalar {
-    fn ensure_zeroized_on_drop(&mut self) {
-        self.zeroize()
-    }
-}
 
 impl RepresentableAsArray for CurveScalar {
     // Currently it's the only size available.
@@ -94,14 +81,8 @@ impl HasTypeName for CurveScalar {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize)]
 pub(crate) struct NonZeroCurveScalar(BackendNonZeroScalar);
-
-impl CanBeZeroizedOnDrop for NonZeroCurveScalar {
-    fn ensure_zeroized_on_drop(&mut self) {
-        self.0.zeroize()
-    }
-}
 
 impl NonZeroCurveScalar {
     /// Generates a random non-zero scalar (in nearly constant-time).
@@ -204,12 +185,6 @@ impl Default for CurvePoint {
 }
 
 impl DefaultIsZeroes for CurvePoint {}
-
-impl CanBeZeroizedOnDrop for CurvePoint {
-    fn ensure_zeroized_on_drop(&mut self) {
-        self.zeroize()
-    }
-}
 
 impl Add<&CurveScalar> for &CurveScalar {
     type Output = CurveScalar;

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -143,13 +143,12 @@ impl DEM {
 #[cfg(test)]
 mod tests {
 
-    use generic_array::GenericArray;
     use typenum::U32;
 
     use super::kdf;
     use crate::curve::CurvePoint;
     use crate::secret_box::SecretBox;
-    use crate::{RepresentableAsArray, SerializableToArray};
+    use crate::SerializableToArray;
 
     #[test]
     fn test_kdf() {
@@ -157,7 +156,6 @@ mod tests {
         let salt = b"abcdefg";
         let info = b"sdasdasd";
         let seed = SecretBox::new(p1.to_array());
-        type PointArray = GenericArray<u8, <CurvePoint as RepresentableAsArray>::Size>;
         let key = kdf::<U32>(seed.as_secret(), Some(&salt[..]), Some(&info[..]));
         let key_same = kdf::<U32>(seed.as_secret(), Some(&salt[..]), Some(&info[..]));
         assert_eq!(key.as_secret(), key_same.as_secret());

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -1,4 +1,4 @@
-use digest::Digest;
+use digest::{Digest, Update};
 use sha2::Sha256;
 
 use crate::curve::{CurvePoint, NonZeroCurveScalar};

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -1,8 +1,9 @@
 use digest::{Digest, Update};
 use sha2::Sha256;
+use zeroize::Zeroize;
 
 use crate::curve::{CurvePoint, NonZeroCurveScalar};
-use crate::secret_box::{CanBeZeroizedOnDrop, SecretBox};
+use crate::secret_box::SecretBox;
 use crate::traits::SerializableToArray;
 
 // Our hash of choice.
@@ -25,7 +26,7 @@ impl Hash {
         Self(self.0.chain(bytes.as_ref()))
     }
 
-    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + CanBeZeroizedOnDrop>(
+    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + Zeroize>(
         self,
         bytes: &SecretBox<T>,
     ) -> Self {
@@ -49,7 +50,7 @@ impl ScalarDigest {
         Self(self.0.chain_bytes(bytes))
     }
 
-    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + CanBeZeroizedOnDrop>(
+    pub fn chain_secret_bytes<T: AsRef<[u8]> + Clone + Zeroize>(
         self,
         bytes: &SecretBox<T>,
     ) -> Self {

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -9,6 +9,7 @@ use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 use signature::{DigestVerifier, RandomizedDigestSigner, Signature as SignatureTrait};
 use typenum::{Unsigned, U32, U64};
+use zeroize::ZeroizeOnDrop;
 
 #[cfg(feature = "default-rng")]
 use rand_core::OsRng;
@@ -94,11 +95,8 @@ impl fmt::Display for Signature {
     }
 }
 
-// TODO (#89): derive `ZeroizeOnDrop` for `SecretKey` when it's available.
-// For now we know that `BackendSecretKey` is zeroized on drop (as of elliptic-curve=0.11),
-// but cannot check that at compile-time.
 /// A secret key.
-#[derive(Clone)]
+#[derive(Clone, ZeroizeOnDrop)]
 pub struct SecretKey(BackendSecretKey<CurveType>);
 
 impl SecretKey {
@@ -173,14 +171,13 @@ fn digest_for_signing(message: &[u8]) -> BackendDigest {
 
 /// An object used to sign messages.
 /// For security reasons cannot be serialized.
-// `k256::SigningKey` is zeroized on `Drop` as of `k256=0.10`.
-#[derive(Clone)]
+#[derive(Clone, ZeroizeOnDrop)]
 pub struct Signer(SigningKey<CurveType>);
 
 impl Signer {
     /// Creates a new signer out of a secret key.
     pub fn new(sk: SecretKey) -> Self {
-        Self(SigningKey::<CurveType>::from(sk.0))
+        Self(SigningKey::<CurveType>::from(sk.0.clone()))
     }
 
     /// Signs the given message using the given RNG.
@@ -302,7 +299,7 @@ pub struct SecretKeyFactory(SecretBox<SecretKeyFactorySeed>);
 impl SecretKeyFactory {
     /// Creates a secret key factory using the given RNG.
     pub fn random_with_rng(rng: &mut (impl CryptoRng + RngCore)) -> Self {
-        let mut bytes = SecretBox::new(GenericArray::<u8, SecretKeyFactorySeedSize>::default());
+        let mut bytes = SecretBox::new(SecretKeyFactorySeed::default());
         rng.fill_bytes(bytes.as_mut_secret());
         Self(bytes)
     }
@@ -345,8 +342,7 @@ impl SecretKeyFactory {
             .cloned()
             .chain(label.iter().cloned())
             .collect();
-        let key =
-            kdf::<SecretKeyFactorySeed, SecretKeyFactoryDerivedSize>(&self.0, None, Some(&info));
+        let key = kdf::<SecretKeyFactoryDerivedSize>(self.0.as_secret(), None, Some(&info));
         let nz_scalar = SecretBox::new(
             ScalarDigest::new_with_dst(&info)
                 .chain_secret_bytes(&key)
@@ -363,8 +359,7 @@ impl SecretKeyFactory {
             .cloned()
             .chain(label.iter().cloned())
             .collect();
-        let derived_seed =
-            kdf::<SecretKeyFactorySeed, SecretKeyFactorySeedSize>(&self.0, None, Some(&info));
+        let derived_seed = kdf::<SecretKeyFactorySeedSize>(self.0.as_secret(), None, Some(&info));
         Self(derived_seed)
     }
 }

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -229,7 +229,7 @@ impl PublicKey {
     /// Verifies the signature.
     pub(crate) fn verify_digest(
         &self,
-        digest: impl Digest<OutputSize = U32>,
+        digest: impl Digest<OutputSize = U32> + digest::FixedOutput,
         signature: &Signature,
     ) -> bool {
         let verifier = VerifyingKey::from(&self.0);

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -152,7 +152,7 @@ pub use pre::{
     decrypt_original, decrypt_reencrypted, encrypt_with_rng, generate_kfrags_with_rng,
     reencrypt_with_rng, ReencryptionError,
 };
-pub use secret_box::{CanBeZeroizedOnDrop, SecretBox};
+pub use secret_box::SecretBox;
 pub use traits::{
     ConstructionError, DeserializableFromArray, DeserializationError, HasTypeName,
     RepresentableAsArray, SerializableToArray, SerializableToSecretArray, SizeMismatchError,

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -44,7 +44,7 @@ pub fn encrypt_with_rng(
     plaintext: &[u8],
 ) -> Result<(Capsule, Box<[u8]>), EncryptionError> {
     let (capsule, key_seed) = Capsule::from_public_key(rng, delegating_pk);
-    let dem = DEM::new(&key_seed);
+    let dem = DEM::new(key_seed.as_secret());
     dem.encrypt(rng, plaintext, &capsule.to_array())
         .map(|ciphertext| (capsule, ciphertext))
 }
@@ -66,7 +66,7 @@ pub fn decrypt_original(
     ciphertext: impl AsRef<[u8]>,
 ) -> Result<Box<[u8]>, DecryptionError> {
     let key_seed = capsule.open_original(delegating_sk);
-    let dem = DEM::new(&key_seed);
+    let dem = DEM::new(key_seed.as_secret());
     dem.decrypt(ciphertext, &capsule.to_array())
 }
 
@@ -184,7 +184,7 @@ pub fn decrypt_reencrypted(
     let key_seed = capsule
         .open_reencrypted(receiving_sk, delegating_pk, &cfrags)
         .map_err(ReencryptionError::OnOpen)?;
-    let dem = DEM::new(&key_seed);
+    let dem = DEM::new(key_seed.as_secret());
     dem.decrypt(&ciphertext, &capsule.to_array())
         .map_err(ReencryptionError::OnDecryption)
 }


### PR DESCRIPTION
- Bumped `k256` to 0.11, `sha2` to 0.10, `hkdf` to 0.12, `chacha20poly1305` to 0.10, and `zeroize` to 1.5 (and MSRV to 1.57), so that we could use the new `ZeroizeOnDrop` functionality. In particular, `SecretBox` and `SecretKey` now implement `ZeroizeOnDrop`. Fixes #89 
- Removed `CanBeZeroizedOnDrop`; `GenericArray` supports `Zeroize` since `generic-array` 0.14.6
- Bumped `pyo3` to 0.16

Note that it is not clear from the documentation, but `#[derive(ZeroizeOnDrop)]` works as follows: if a field is `ZeroizeOnDrop`, it is skipped, if it's `Zeroize`, it's zeroized, if it's neither, an error is raised. So e.g. in the case when it's derived for `SecretKey` there won't be double zeroization (because the `k256::SecretKey` implements `ZeroizeOnDrop` itself), but rather a compile-time check that the whole object is correctly zeroized on drop.