### PR TITLE
Fix some typos and add missing methods to Python typing stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `serde` utility functions to serialize bytestrings as bytes or hex/base64 encoded strings, depending on the target format. Exposed as `serde_bytes` module. ([#94])
 
 
+### Fixed
+
+- Fixed some typos and added missing `__bytes__()` methods to Python typing stubs. ([#99])
+
+
 [#94]: https://github.com/nucypher/rust-umbral/pull/94
 [#97]: https://github.com/nucypher/rust-umbral/pull/97
+[#99]: https://github.com/nucypher/rust-umbral/pull/99
 
 
 ## [0.5.2] - 2022-03-15

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -67,19 +67,19 @@ class PublicKey:
 
 class Signer:
 
-    def __init__(secret_key: SecretKey):
+    def __init__(self, secret_key: SecretKey):
         ...
 
-    def sign(message: bytes) -> Signature:
+    def sign(self, message: bytes) -> Signature:
         ...
 
-    def verifying_key() -> PublicKey:
+    def verifying_key(self) -> PublicKey:
         ...
 
 
 class Signature:
 
-    def verify(verifying_pk: PublicKey, message: bytes) -> bool:
+    def verify(self, verifying_pk: PublicKey, message: bytes) -> bool:
         ...
 
     @staticmethod
@@ -130,7 +130,7 @@ class KeyFrag:
 
 class VerifiedKeyFrag:
 
-    def from_verified_bytes(data: bytes) -> VerifiedKeyFrag:
+    def from_verified_bytes(self, data: bytes) -> VerifiedKeyFrag:
         ...
 
     def unverify(self) -> KeyFrag:
@@ -178,6 +178,7 @@ class CapsuleFrag:
 
 class VerifiedCapsuleFrag:
 
+    @staticmethod
     def from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag:
         ...
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -60,6 +60,9 @@ class PublicKey:
     def from_bytes() -> PublicKey:
         ...
 
+    def __bytes__(self) -> bytes:
+        ...
+
     @staticmethod
     def serialized_size() -> int:
         ...
@@ -86,6 +89,9 @@ class Signature:
     def from_bytes() -> Signature:
         ...
 
+    def __bytes__(self) -> bytes:
+        ...
+
     @staticmethod
     def serialized_size() -> int:
         ...
@@ -95,6 +101,13 @@ class Capsule:
 
     @staticmethod
     def serialized_size() -> int:
+        ...
+
+    @staticmethod
+    def from_bytes() -> Capsule:
+        ...
+
+    def __bytes__(self) -> bytes:
         ...
 
 
@@ -123,6 +136,9 @@ class KeyFrag:
     def from_bytes() -> KeyFrag:
         ...
 
+    def __bytes__(self) -> bytes:
+        ...
+
     @staticmethod
     def serialized_size() -> int:
         ...
@@ -131,6 +147,9 @@ class KeyFrag:
 class VerifiedKeyFrag:
 
     def from_verified_bytes(self, data: bytes) -> VerifiedKeyFrag:
+        ...
+
+    def __bytes__(self) -> bytes:
         ...
 
     def unverify(self) -> KeyFrag:
@@ -171,6 +190,9 @@ class CapsuleFrag:
     def from_bytes() -> CapsuleFrag:
         ...
 
+    def __bytes__(self) -> bytes:
+        ...
+
     @staticmethod
     def serialized_size() -> int:
         ...
@@ -180,6 +202,9 @@ class VerifiedCapsuleFrag:
 
     @staticmethod
     def from_verified_bytes(data: bytes) -> VerifiedCapsuleFrag:
+        ...
+
+    def __bytes__(self) -> bytes:
         ...
 
     def unverify(self) -> CapsuleFrag:


### PR DESCRIPTION
- Add missing `self` parameters to instance methods
- Add explicit `__bytes__()` methods