### PR TITLE
Fix some clippy warnings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.57.0 # MSRV
+        toolchain: stable
         components: clippy
         override: true
         profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under construction.
+### Added
+
+- `Eq` markers for the types that only had `PartialEq` before. ([#100])
+
+
+[#100]: https://github.com/nucypher/rust-umbral/pull/100
 
 
 ## [0.6.0] - 2022-08-15

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -3,6 +3,10 @@
 // TODO (#30): ideally, we would write documentation for the bindings as docstrings here,
 // and let Sphinx pick it up... but it's not great at doing so.
 #![allow(missing_docs)]
+// Clippy shows false positives in PyO3 methods.
+// See https://github.com/rust-lang/rust-clippy/issues/8971
+// Will probably be fixed by Rust 1.65
+#![allow(clippy::borrow_deref_ref)]
 
 use alloc::format;
 use alloc::string::String;
@@ -222,7 +226,7 @@ impl SecretKeyFactory {
 }
 
 #[pyclass(module = "umbral")]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PublicKey {
     pub backend: umbral_pre::PublicKey,
 }
@@ -306,7 +310,7 @@ impl Signer {
 }
 
 #[pyclass(module = "umbral")]
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct Signature {
     backend: umbral_pre::Signature,
 }

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -24,7 +24,7 @@ use crate::traits::{
 use crate::serde_bytes::{deserialize_with_encoding, serialize_as_array, Encoding};
 
 /// Errors that can happen when opening a `Capsule` using reencrypted `CapsuleFrag` objects.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum OpenReencryptedError {
     /// An empty capsule fragment list is given.
     NoCapsuleFrags,

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -196,7 +196,7 @@ impl fmt::Display for CapsuleFrag {
 }
 
 /// Possible errors that can be returned by [`CapsuleFrag::verify`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CapsuleFragVerificationError {
     /// Inconsistent internal state leading to signature verification failure.
     IncorrectKeyFragSignature,

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -13,7 +13,7 @@ use zeroize::ZeroizeOnDrop;
 use crate::secret_box::SecretBox;
 
 /// Errors that can happen during symmetric encryption.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EncryptionError {
     /// Given plaintext is too large for the backend to handle.
     PlaintextTooLarge,
@@ -28,7 +28,7 @@ impl fmt::Display for EncryptionError {
 }
 
 /// Errors that can happend during symmetric decryption.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DecryptionError {
     /// Ciphertext (which should be prepended by the nonce) is shorter than the nonce length.
     CiphertextTooShort,

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -239,7 +239,7 @@ impl fmt::Display for KeyFrag {
 }
 
 /// Possible errors that can be returned by [`KeyFrag::verify`].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum KeyFragVerificationError {
     /// Inconsistent internal state leading to commitment verification failure.
     IncorrectCommitment,

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -30,7 +30,7 @@ use crate::traits::{
 use crate::serde_bytes::{deserialize_with_encoding, serialize_as_array, Encoding};
 
 /// ECDSA signature object.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Signature(BackendSignature<CurveType>);
 
 impl RepresentableAsArray for Signature {
@@ -214,7 +214,7 @@ impl fmt::Display for Signer {
 /// A public key.
 ///
 /// Create using [`SecretKey::public_key`].
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PublicKey(BackendPublicKey<CurveType>);
 
 impl PublicKey {

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -18,7 +18,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 /// Errors that can happen when decrypting a reencrypted ciphertext.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ReencryptionError {
     /// An error when opening a capsule. See [`OpenReencryptedError`] for the options.
     OnOpen(OpenReencryptedError),

--- a/umbral-pre/src/traits.rs
+++ b/umbral-pre/src/traits.rs
@@ -11,7 +11,7 @@ use typenum::{Diff, Unsigned, U1, U8};
 use crate::secret_box::SecretBox;
 
 /// Errors that can happen during deserializing an object from a bytestring of correct length.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ConstructionError {
     /// The name of the type that was being deserialized
     /// (can be one of the nested fields).
@@ -41,7 +41,7 @@ impl fmt::Display for ConstructionError {
 }
 
 /// The provided bytestring is of an incorrect size.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SizeMismatchError {
     pub(crate) received_size: usize,
     pub(crate) expected_size: usize,
@@ -68,7 +68,7 @@ impl fmt::Display for SizeMismatchError {
 }
 
 /// Errors that can happen during object deserialization.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DeserializationError {
     /// Failed to construct the object from a given bytestring (with the correct length).
     ConstructionFailure(ConstructionError),


### PR DESCRIPTION
- Fix `clippy` warnings about missing `Eq`
- Disable `borrow_deref_ref` warning temporarily, since it is triggered for all PyO3 macro-generated methods
- Run `clippy` on stable instead of MSRV in the CI