### PR TITLE
Remove `wee_alloc`

### DIFF
--- a/umbral-pre-wasm/Cargo.toml
+++ b/umbral-pre-wasm/Cargo.toml
@@ -16,4 +16,3 @@ crate-type = ["cdylib", "rlib"]
 umbral-pre = { path = "../umbral-pre", features = ["bindings-wasm"] }
 wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
-wee_alloc = "0.4"

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -1,11 +1,6 @@
 #![allow(clippy::unused_unit)] // Temporarily silence the warnings introduced in wasm-bindgen 0.2.79
 #![no_std]
 
-// Use `wee_alloc` as the global allocator.
-extern crate wee_alloc;
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 extern crate alloc;
 
 pub use umbral_pre::bindings_wasm::*;

--- a/umbral-pre-wasm/src/lib.rs
+++ b/umbral-pre-wasm/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::unused_unit)] // Temporarily silence the warnings introduced in wasm-bindgen 0.2.79
 #![no_std]
 
 extern crate alloc;


### PR DESCRIPTION
- `wee_alloc` has not been updated in a few years, and Dependabot shows a warning about it being unmaintained. Removing it does not even change the wasm size too much - 263kb to 269kb.
- Also removed an old exception for `clippy`; `wasm-bindgen` seems to have fixed the problem