### PR TITLE
Bump and group dependencies

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -40,7 +40,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       #- run: cp ../../Cargo.lock .. # Use same Cargo.lock resolution that's checked in
-      - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --features bindings-wasm --release --target ${{ matrix.target }}
 
   build-arm:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `VerifiedCapsuleFrag::from_verified_bytes()` and `VerifiedKeyFrag::from_verified_bytes()`. For this behavior, deserialize into `CapsuleFrag` or `KeyFrag` and call `skip_verification()`. ([#110])
 - `Capsule` no longer implements `Copy`. ([#110])
 - Removed default serialization methods for `PublicKey` and `Signature` in the bindings; use `to_compressed_bytes()`/`to_der_bytes()` instead. ([#110])
+- Bumped `rmp-serde` to 1, `base64` to 0.21, and `pyo3` to 0.17. (#[114])
 
 
 ### Added
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#105]: https://github.com/nucypher/rust-umbral/pull/105
 [#110]: https://github.com/nucypher/rust-umbral/pull/110
 [#112]: https://github.com/nucypher/rust-umbral/pull/112
+[#114]: https://github.com/nucypher/rust-umbral/pull/114
 
 
 ## [0.7.0] - 2022-09-30

--- a/umbral-pre-python/Cargo.toml
+++ b/umbral-pre-python/Cargo.toml
@@ -9,9 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 umbral-pre = { path = "../umbral-pre", features = ["bindings-python"] }
-generic-array = "0.14"
 
 # Unfortunately, we (for the time being?) cannot use a re-exported `pyo3`
 # from the main `umbral-pre`, since `pyo3` macros and `pip` build need an explicit dependency.
 # This version has to be matched with the one in `umbral-pre`.
-pyo3 = "0.16"
+pyo3 = "0.17"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -16,8 +16,9 @@ chacha20poly1305 = { version = "0.10", default-features = false, features = ["al
 hkdf = { version = "0.12", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
-base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-pyo3 = { version = "0.16", optional = true }
+base64 = { version = "0.21", default-features = false, features = ["alloc"] }
+rmp-serde = { version = "1", optional = true }
+pyo3 = { version = "0.17", optional = true }
 js-sys = { version = "0.3", optional = true }
 wasm-bindgen = { version = "0.2.74", optional = true }
 derive_more = { version = "0.99", optional = true, default_features = false, features = ["as_ref", "from", "into"] }
@@ -25,29 +26,23 @@ wasm-bindgen-derive = { version = "0.1", optional = true }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.
-elliptic-curve = { version = "0.12" }
-digest = "0.10"
 generic-array = { version = "0.14.6", features = ["zeroize"] }
-aead = { version = "0.5", default-features = false }
 ecdsa = { version = "0.14.4" } # Pin patch version to enable ZeroizeOnDrop for SigningKey
-signature = { version = "1.5", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-typenum = "1.13" # typenum is a 2018-edition crate starting from 1.13
-getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }
+getrandom = { version = "0.2", optional = true, default-features = false }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1.5", default-features = false, features = ["derive"] }
-rmp-serde = { version = "0.15", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.4", features = ["html_reports"] }
 serde_json = "1"
-rmp-serde = "0.15"
+rmp-serde = "1"
 
 [features]
 default = ["default-rng"]
 bench-internals = ["default-rng"]
 bindings-python = ["pyo3", "std", "derive_more", "default-serialization"]
-bindings-wasm = ["js-sys", "default-serialization", "wasm-bindgen", "derive_more", "wasm-bindgen-derive"]
+bindings-wasm = ["js-sys", "default-serialization", "wasm-bindgen", "derive_more", "wasm-bindgen-derive", "getrandom/js"]
 default-rng = ["getrandom", "rand_core/getrandom"]
 default-serialization = ["serde-support", "rmp-serde"]
 serde-support = ["serde"]
@@ -55,7 +50,7 @@ std = []
 
 # What features to use when building documentation on docs.rs
 [package.metadata.docs.rs]
-features = ["serde-support"]
+features = ["default-rng", "default-serialization"]
 # Used to conditionally enable the unstable feature `doc-cfg`
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -7,21 +7,28 @@ use alloc::string::String;
 use core::default::Default;
 use core::ops::{Add, Mul, Sub};
 
-use digest::Digest;
-use elliptic_curve::bigint::U256; // Note that this type is different from typenum::U256
-use elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
-use elliptic_curve::ops::Reduce;
-use elliptic_curve::sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint};
-use elliptic_curve::{Field, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar};
-use generic_array::GenericArray;
-use k256::Secp256k1;
+use k256::{
+    elliptic_curve::{
+        bigint::U256, // Note that this type is different from typenum::U256
+        generic_array::GenericArray,
+        hash2curve::{ExpandMsgXmd, GroupDigest},
+        ops::Reduce,
+        sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
+        Field,
+        FieldSize,
+        NonZeroScalar,
+        ProjectiveArithmetic,
+        Scalar,
+    },
+    Secp256k1,
+};
 use rand_core::{CryptoRng, RngCore};
-use sha2::Sha256;
+use sha2::{digest::Digest, Sha256};
 use subtle::CtOption;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
 #[cfg(feature = "serde-support")]
-use elliptic_curve::group::ff::PrimeField;
+use k256::elliptic_curve::group::ff::PrimeField;
 
 #[cfg(feature = "serde-support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/umbral-pre/src/dem.rs
+++ b/umbral-pre/src/dem.rs
@@ -1,13 +1,14 @@
 use alloc::boxed::Box;
 use core::fmt;
 
-use aead::{Aead, AeadCore, Payload};
-use chacha20poly1305::{Key, KeyInit, KeySizeUser, XChaCha20Poly1305, XNonce};
-use generic_array::{ArrayLength, GenericArray};
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, Payload},
+    Key, KeyInit, KeySizeUser, XChaCha20Poly1305, XNonce,
+};
+use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use hkdf::Hkdf;
 use rand_core::{CryptoRng, RngCore};
 use sha2::Sha256;
-use typenum::Unsigned;
 use zeroize::ZeroizeOnDrop;
 
 use crate::secret_box::SecretBox;
@@ -143,7 +144,7 @@ impl DEM {
 #[cfg(test)]
 mod tests {
 
-    use typenum::U32;
+    use generic_array::typenum::U32;
 
     use super::kdf;
     use crate::curve::CurvePoint;

--- a/umbral-pre/src/hashing.rs
+++ b/umbral-pre/src/hashing.rs
@@ -1,5 +1,7 @@
-use digest::{Digest, Update};
-use sha2::Sha256;
+use sha2::{
+    digest::{Digest, Update},
+    Sha256,
+};
 use zeroize::Zeroize;
 
 use crate::curve::{CurvePoint, NonZeroCurveScalar};

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -5,9 +5,8 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
 
-use generic_array::GenericArray;
+use generic_array::{typenum::U32, GenericArray};
 use rand_core::{CryptoRng, RngCore};
-use typenum::U32;
 
 #[cfg(feature = "serde-support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -4,13 +4,17 @@ use alloc::string::String;
 use core::cmp::Ordering;
 use core::fmt;
 
-use digest::Digest;
-use ecdsa::{Signature as BackendSignature, SigningKey, VerifyingKey};
-use elliptic_curve::{PublicKey as BackendPublicKey, SecretKey as BackendSecretKey};
-use generic_array::GenericArray;
+use ecdsa::{
+    signature::{DigestVerifier, RandomizedDigestSigner},
+    Signature as BackendSignature, SigningKey, VerifyingKey,
+};
+use generic_array::{
+    typenum::{Unsigned, U32, U64},
+    GenericArray,
+};
+use k256::elliptic_curve::{PublicKey as BackendPublicKey, SecretKey as BackendSecretKey};
 use rand_core::{CryptoRng, RngCore};
-use signature::{DigestVerifier, RandomizedDigestSigner};
-use typenum::{Unsigned, U32, U64};
+use sha2::digest::{Digest, FixedOutput};
 use zeroize::ZeroizeOnDrop;
 
 #[cfg(feature = "default-rng")]
@@ -209,7 +213,7 @@ impl PublicKey {
     /// Verifies the signature.
     pub(crate) fn verify_digest(
         &self,
-        digest: impl Digest<OutputSize = U32> + digest::FixedOutput,
+        digest: impl Digest<OutputSize = U32> + FixedOutput,
         signature: &Signature,
     ) -> bool {
         let verifier = VerifyingKey::from(&self.0);


### PR DESCRIPTION
- Bump `rmp-serde` to 1, `base64` to 0.21, and `pyo3` to 0.17.
- Remove second-level dependencies where applicable (e.g. use `generic_array::typenum` instead of `typenum`)
- Don't use `getrandom/js` unless building WASM bindings