### PR TITLE
Serialization methods for Eth contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under construction.
+### Added
+
+- Added `Signature::to_be_bytes()`, `Capsule::to_bytes_simple()`, and `CapsuleFrag::to_bytes_simple()` to use in Ethereum contracts. ([#115])
+
+
+### Fixed
+
+- Added the missing `VerifiedCapsuleFrag::unverify()` method in WASM bindings. ([#115])
+- Added the missing `Signature::to_der_bytes()` and `from_der_bytes()` that were missing in the Rust library but present in the bindings. ([#115])
+
+
+[#115]: https://github.com/nucypher/rust-umbral/pull/115
 
 
 ## [0.8.0] - 2023-01-15
@@ -220,7 +231,7 @@ the corresponding methods in Python and WASM bindings. ([#84])
 
 - Initial release.
 
-[Unreleased]: https://github.com/nucypher/rust-umbral/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/nucypher/rust-umbral/compare/v0.8.0...HEAD
 [0.2.0]: https://github.com/nucypher/rust-umbral/releases/tag/v0.2.0
 [0.3.0]: https://github.com/nucypher/rust-umbral/releases/tag/v0.3.0
 [0.4.0]: https://github.com/nucypher/rust-umbral/releases/tag/v0.4.0

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -93,6 +93,9 @@ class Capsule:
     def __bytes__(self) -> bytes:
         ...
 
+    def to_bytes_simple(self) -> bytes:
+        ...
+
 
 def encrypt(delegating_pk: PublicKey, plaintext: bytes) -> Tuple[Capsule, bytes]:
     ...
@@ -163,6 +166,9 @@ class CapsuleFrag:
         ...
 
     def __bytes__(self) -> bytes:
+        ...
+
+    def to_bytes_simple(self) -> bytes:
         ...
 
 

--- a/umbral-pre-python/umbral_pre/__init__.pyi
+++ b/umbral-pre-python/umbral_pre/__init__.pyi
@@ -80,6 +80,9 @@ class Signature:
     def to_der_bytes(self) -> bytes:
         ...
 
+    def to_be_bytes(self) -> bytes:
+        ...
+
 
 class Capsule:
 

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -244,6 +244,11 @@ impl Signature {
         Python::with_gil(|py| PyBytes::new(py, &serialized).into())
     }
 
+    fn to_be_bytes(&self) -> PyObject {
+        let serialized = self.backend.to_be_bytes();
+        Python::with_gil(|py| PyBytes::new(py, &serialized).into())
+    }
+
     fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
         self.backend.verify(&verifying_pk.backend, message)
     }

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -283,6 +283,11 @@ impl Capsule {
         to_bytes(self)
     }
 
+    fn to_bytes_simple(&self) -> PyObject {
+        let serialized = self.backend.to_bytes_simple();
+        Python::with_gil(|py| PyBytes::new(py, &serialized).into())
+    }
+
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
@@ -473,6 +478,11 @@ impl CapsuleFrag {
 
     fn __bytes__(&self) -> PyResult<PyObject> {
         to_bytes(self)
+    }
+
+    fn to_bytes_simple(&self) -> PyObject {
+        let serialized = self.backend.to_bytes_simple();
+        Python::with_gil(|py| PyBytes::new(py, &serialized).into())
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {

--- a/umbral-pre/src/bindings_wasm.rs
+++ b/umbral-pre/src/bindings_wasm.rs
@@ -364,6 +364,10 @@ pub struct VerifiedCapsuleFrag(umbral_pre::VerifiedCapsuleFrag);
 
 #[wasm_bindgen]
 impl VerifiedCapsuleFrag {
+    pub fn unverify(&self) -> CapsuleFrag {
+        CapsuleFrag(self.0.clone().unverify())
+    }
+
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Result<Box<[u8]>, Error> {
         self.0.to_bytes().map_err(map_js_err)

--- a/umbral-pre/src/bindings_wasm.rs
+++ b/umbral-pre/src/bindings_wasm.rs
@@ -240,6 +240,11 @@ impl Signature {
         self.0.to_der_bytes()
     }
 
+    #[wasm_bindgen(js_name = toBEBytes)]
+    pub fn to_be_bytes(&self) -> Box<[u8]> {
+        self.0.to_be_bytes()
+    }
+
     #[wasm_bindgen(js_name = fromDerBytes)]
     pub fn from_der_bytes(data: &[u8]) -> Result<Signature, Error> {
         umbral_pre::Signature::try_from_der_bytes(data)

--- a/umbral-pre/src/bindings_wasm.rs
+++ b/umbral-pre/src/bindings_wasm.rs
@@ -275,6 +275,11 @@ impl Capsule {
         self.0.to_bytes().map_err(map_js_err)
     }
 
+    #[wasm_bindgen(js_name = toBytesSimple)]
+    pub fn to_bytes_simple(&self) -> Box<[u8]> {
+        self.0.to_bytes_simple()
+    }
+
     #[wasm_bindgen(js_name = fromBytes)]
     pub fn from_bytes(data: &[u8]) -> Result<Capsule, Error> {
         umbral_pre::Capsule::from_bytes(data)
@@ -322,6 +327,11 @@ impl CapsuleFrag {
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Result<Box<[u8]>, Error> {
         self.0.to_bytes().map_err(map_js_err)
+    }
+
+    #[wasm_bindgen(js_name = toBytesSimple)]
+    pub fn to_bytes_simple(&self) -> Box<[u8]> {
+        self.0.to_bytes_simple()
     }
 
     #[wasm_bindgen(js_name = fromBytes)]

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -131,17 +131,16 @@ impl Capsule {
         }
     }
 
-    pub(crate) fn to_associated_data_bytes(&self) -> Box<[u8]> {
+    /// Serializes the capsule by concatenating the byte represenation of its constituents:
+    /// - `e` (compressed curve point, 33 bytes),
+    /// - `v` (compressed curve point, 33 bytes),
+    /// - `signature` (big-endian scalar, 32 bytes).
+    pub fn to_bytes_simple(&self) -> Box<[u8]> {
         let e = self.point_e.to_compressed_array();
         let v = self.point_v.to_compressed_array();
         let s = self.signature.to_array();
-
-        let e_ref: &[u8] = e.as_ref();
-        let v_ref: &[u8] = v.as_ref();
-        let s_ref: &[u8] = s.as_ref();
-
-        let v: Vec<u8> = [e_ref, v_ref, s_ref].concat();
-        v.into()
+        let v: &[&[u8]] = &[&e, &v, &s];
+        v.concat().into()
     }
 
     /// Verifies the integrity of the capsule.

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -39,12 +39,13 @@ use crate::serde_bytes::{
 pub struct Signature(BackendSignature<CurveType>);
 
 impl Signature {
-    pub(crate) fn to_der_bytes(&self) -> Box<[u8]> {
+    /// Returns the signature serialized in ASN.1 DER format.
+    pub fn to_der_bytes(&self) -> Box<[u8]> {
         self.0.to_der().as_bytes().into()
     }
 
-    #[cfg(feature = "serde-support")]
-    pub(crate) fn try_from_der_bytes(bytes: &[u8]) -> Result<Self, String> {
+    /// Restores the signature from a bytestring in ASN.1 DER format.
+    pub fn try_from_der_bytes(bytes: &[u8]) -> Result<Self, String> {
         // Note that it will not normalize `s` automatically,
         // and if it is not normalized, verification will fail.
         BackendSignature::<CurveType>::from_der(bytes)

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -52,6 +52,12 @@ impl Signature {
             .map(Self)
             .map_err(|err| format!("Internal backend error: {}", err))
     }
+
+    /// Verifies that the given message was signed with the secret counterpart of the given key.
+    /// The message is hashed internally.
+    pub fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
+        verifying_pk.verify_digest(digest_for_signing(message), self)
+    }
 }
 
 #[cfg(feature = "serde-support")]
@@ -82,14 +88,6 @@ impl TryFromBytes for Signature {
 
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
         Self::try_from_der_bytes(bytes)
-    }
-}
-
-impl Signature {
-    /// Verifies that the given message was signed with the secret counterpart of the given key.
-    /// The message is hashed internally.
-    pub fn verify(&self, verifying_pk: &PublicKey, message: &[u8]) -> bool {
-        verifying_pk.verify_digest(digest_for_signing(message), self)
     }
 }
 

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use core::fmt;
 
 use ecdsa::{
-    signature::{DigestVerifier, RandomizedDigestSigner},
+    signature::{DigestVerifier, RandomizedDigestSigner, Signature as SignatureTrait},
     Signature as BackendSignature, SigningKey, VerifyingKey,
 };
 use generic_array::{
@@ -39,6 +39,12 @@ use crate::serde_bytes::{
 pub struct Signature(BackendSignature<CurveType>);
 
 impl Signature {
+    /// Returns the signature serialized as concatenated `r` and `s`
+    /// in big endian order (32+32 bytes).
+    pub fn to_be_bytes(&self) -> Box<[u8]> {
+        self.0.as_bytes().into()
+    }
+
     /// Returns the signature serialized in ASN.1 DER format.
     pub fn to_der_bytes(&self) -> Box<[u8]> {
         self.0.to_der().as_bytes().into()

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -11,6 +11,9 @@
 //! ## Available feature flags
 //!
 //! * `default-rng` - adds methods that use the system RNG (default).
+//! * `default-serialization` - adds methods for default binary serialization
+//!    that matches the serialization in the bindings.
+//!    MessagePack, `serde`-based.
 //! * `serde-support` - implements `serde`-based serialization and deserialization.
 //! * `bindings-python` - adds a `bindings_python` submodule allowing dependent crates
 //!        to use and re-export some of the Python-wrapped Umbral types.

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -44,7 +44,7 @@ pub fn encrypt_with_rng(
 ) -> Result<(Capsule, Box<[u8]>), EncryptionError> {
     let (capsule, key_seed) = Capsule::from_public_key(rng, delegating_pk);
     let dem = DEM::new(key_seed.as_secret());
-    dem.encrypt(rng, plaintext, &capsule.to_associated_data_bytes())
+    dem.encrypt(rng, plaintext, &capsule.to_bytes_simple())
         .map(|ciphertext| (capsule, ciphertext))
 }
 
@@ -66,7 +66,7 @@ pub fn decrypt_original(
 ) -> Result<Box<[u8]>, DecryptionError> {
     let key_seed = capsule.open_original(delegating_sk);
     let dem = DEM::new(key_seed.as_secret());
-    dem.decrypt(ciphertext, &capsule.to_associated_data_bytes())
+    dem.decrypt(ciphertext, &capsule.to_bytes_simple())
 }
 
 /// Creates `shares` fragments of `delegating_sk`,
@@ -184,7 +184,7 @@ pub fn decrypt_reencrypted(
         .open_reencrypted(receiving_sk, delegating_pk, &cfrags)
         .map_err(ReencryptionError::OnOpen)?;
     let dem = DEM::new(key_seed.as_secret());
-    dem.decrypt(&ciphertext, &capsule.to_associated_data_bytes())
+    dem.decrypt(&ciphertext, &capsule.to_bytes_simple())
         .map_err(ReencryptionError::OnDecryption)
 }
 


### PR DESCRIPTION
- Added `Signature::to_be_bytes()`, `Capsule::to_bytes_simple()`, and `CapsuleFrag::to_bytes_simple()` to use in Ethereum contracts.

Also:
- Added the missing `VerifiedCapsuleFrag::unverify()` method in WASM bindings.
- Added the missing `Signature::to_der_bytes()` and `from_der_bytes()` that were missing in the Rust library but present in the bindings.