### PR TITLE
Use llvm-cov instead of tarpaulin

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -112,23 +112,24 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           profile: minimal
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
           override: true
-      - uses: actions-rs/tarpaulin@v0.1
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      # Only checking the coverage of the main library,
+      # bindings are covered by their language's tests.
+      # Also have to exclude `umbral-pre-python` explicitly,
+      # since it cannot be compiled for testing
+      # (https://github.com/PyO3/pyo3/issues/340)
+      - name: Generate code coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --exclude umbral-pre-wasm --exclude umbral-pre-python --all-features
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
         with:
-          version: latest
-          # Only checking the coverage of the main library,
-          # bindings are covered by their language's tests.
-          # Also have to exclude `umbral-pre-python` explicitly,
-          # since it cannot be compiled for testing
-          # (https://github.com/PyO3/pyo3/issues/340)
-          args: --exclude-files umbral-pre-wasm/** --exclude-files umbral-pre-python/** --workspace --exclude umbral-pre-python --all-features -- --test-threads 1
-      - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
`llvm-cov` can be run on Mac too, which simplifies development. Also seems to be less buggy.