### PR TITLE
Rename `serde-support` feature to `serde`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped MSRV to 1.60. ([#117])
 - Bumped `k256` to 0.12 and PyO3 to `0.18`. ([#117])
+- Renamed `serde-support` feature to `serde` to match the conventional style. ([#118])
 
 
 ### Added
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#107]: https://github.com/nucypher/rust-umbral/pull/107
 [#117]: https://github.com/nucypher/rust-umbral/pull/117
+[#118]: https://github.com/nucypher/rust-umbral/pull/118
 
 
 ## [0.8.1] - 2023-01-17

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -43,8 +43,8 @@ bench-internals = ["default-rng"]
 bindings-python = ["pyo3", "std", "derive_more", "default-serialization"]
 bindings-wasm = ["js-sys", "default-serialization", "wasm-bindgen", "derive_more", "wasm-bindgen-derive", "getrandom/js"]
 default-rng = ["getrandom", "rand_core/getrandom"]
-default-serialization = ["serde-support", "rmp-serde"]
-serde-support = ["serde"]
+default-serialization = ["serde", "rmp-serde"]
+serde = ["dep:serde"]
 std = []
 
 # What features to use when building documentation on docs.rs

--- a/umbral-pre/src/capsule.rs
+++ b/umbral-pre/src/capsule.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use alloc::string::String;
 
 use alloc::boxed::Box;
@@ -8,7 +8,7 @@ use core::fmt;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::capsule_frag::CapsuleFrag;
@@ -52,7 +52,7 @@ impl fmt::Display for OpenReencryptedError {
 /// A helper struct:
 /// - allows us not to serialize `params`
 /// - allows us to verify the capsule on deserialization.
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 struct SerializedCapsule {
     point_e: CurvePoint,
@@ -62,9 +62,9 @@ struct SerializedCapsule {
 
 /// Encapsulated symmetric key used to encrypt the plaintext.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde-support", serde(try_from = "SerializedCapsule"))]
-#[cfg_attr(feature = "serde-support", serde(into = "SerializedCapsule"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "SerializedCapsule"))]
+#[cfg_attr(feature = "serde", serde(into = "SerializedCapsule"))]
 pub struct Capsule {
     pub(crate) params: Parameters,
     pub(crate) point_e: CurvePoint,
@@ -72,7 +72,7 @@ pub struct Capsule {
     pub(crate) signature: CurveScalar,
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFrom<SerializedCapsule> for Capsule {
     type Error = String;
 
@@ -82,7 +82,7 @@ impl TryFrom<SerializedCapsule> for Capsule {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl From<Capsule> for SerializedCapsule {
     fn from(source: Capsule) -> Self {
         Self {
@@ -118,7 +118,7 @@ impl Capsule {
         }
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     pub(crate) fn new_verified(
         point_e: CurvePoint,
         point_v: CurvePoint,
@@ -144,7 +144,7 @@ impl Capsule {
     }
 
     /// Verifies the integrity of the capsule.
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     fn verify(&self) -> bool {
         let g = CurvePoint::generator();
         let h = hash_capsule_points(&self.point_e, &self.point_v);
@@ -267,7 +267,7 @@ mod tests {
 
     use crate::{generate_kfrags, reencrypt, SecretKey, Signer};
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     use crate::serde_bytes::tests::check_serialization_roundtrip;
 
     #[test]
@@ -331,7 +331,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serde_serialization() {
         let delegating_sk = SecretKey::random();

--- a/umbral-pre/src/capsule_frag.rs
+++ b/umbral-pre/src/capsule_frag.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::capsule::Capsule;
@@ -18,7 +18,7 @@ use crate::traits::fmt_public;
 use crate::{DefaultDeserialize, DefaultSerialize};
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) struct CapsuleFragProof {
     pub(crate) point_e2: CurvePoint,
     pub(crate) point_v2: CurvePoint,
@@ -76,7 +76,7 @@ impl CapsuleFragProof {
 
 /// A reencrypted fragment of a [`Capsule`] created by a proxy.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CapsuleFrag {
     pub(crate) point_e1: CurvePoint,
     pub(crate) point_v1: CurvePoint,
@@ -258,8 +258,8 @@ impl<'de> DefaultDeserialize<'de> for CapsuleFrag {}
 /// Can be serialized, but cannot be deserialized directly.
 /// It can only be obtained from [`CapsuleFrag::verify`] or [`CapsuleFrag::skip_verification`].
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize))]
-#[cfg_attr(feature = "serde-support", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct VerifiedCapsuleFrag {
     cfrag: CapsuleFrag,
 }
@@ -308,7 +308,7 @@ mod tests {
 
     use crate::{encrypt, generate_kfrags, reencrypt, Capsule, PublicKey, SecretKey, Signer};
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     use crate::serde_bytes::tests::check_serialization_roundtrip;
 
     fn prepare_cfrags() -> (
@@ -361,7 +361,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serde_serialization() {
         let (_delegating_pk, _receiving_pk, _verifying_pk, _capsule, verified_cfrags) =

--- a/umbral-pre/src/curve.rs
+++ b/umbral-pre/src/curve.rs
@@ -28,13 +28,13 @@ use sha2::{digest::Digest, Sha256};
 use subtle::CtOption;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
-#[cfg(any(feature = "serde-support", test))]
+#[cfg(any(feature = "serde", test))]
 use k256::elliptic_curve::group::ff::PrimeField;
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use crate::serde_bytes::{
     deserialize_with_encoding, serialize_with_encoding, Encoding, TryFromBytes,
 };
@@ -70,7 +70,7 @@ impl CurveScalar {
         self.0.to_bytes()
     }
 
-    #[cfg(any(feature = "serde-support", test))]
+    #[cfg(any(feature = "serde", test))]
     pub(crate) fn try_from_bytes(bytes: &[u8]) -> Result<Self, String> {
         let arr = GenericArray::<u8, ScalarSize>::from_exact_iter(bytes.iter().cloned())
             .ok_or("Invalid length of a curve scalar")?;
@@ -83,7 +83,7 @@ impl CurveScalar {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl Serialize for CurveScalar {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -93,7 +93,7 @@ impl Serialize for CurveScalar {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for CurveScalar {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -103,7 +103,7 @@ impl<'de> Deserialize<'de> for CurveScalar {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for CurveScalar {
     type Error = String;
 
@@ -230,7 +230,7 @@ impl Default for CurvePoint {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl Serialize for CurvePoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -240,7 +240,7 @@ impl Serialize for CurvePoint {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for CurvePoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -250,7 +250,7 @@ impl<'de> Deserialize<'de> for CurvePoint {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for CurvePoint {
     type Error = String;
 

--- a/umbral-pre/src/evidence.rs
+++ b/umbral-pre/src/evidence.rs
@@ -2,7 +2,7 @@ use alloc::string::{String, ToString};
 
 use sha2::digest::Digest;
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::curve::CurvePoint;
@@ -46,7 +46,7 @@ use crate::{DefaultDeserialize, DefaultSerialize};
 /// `h` is the challenge scalar, see [`hash_to_cfrag_verification`]
 /// for the details on how to reproduce its calculation.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReencryptionEvidence {
     /// Same as `e` in [`Capsule::to_bytes_simple`].
     pub e: CurvePoint,
@@ -81,7 +81,7 @@ pub struct ReencryptionEvidence {
     pub u2: CurvePoint,
     /// The hashed message used to create `kfrag_signature` in
     /// [`CapsuleFrag::to_bytes_simple`].
-    #[cfg_attr(feature = "serde-support", serde(with = "crate::serde_bytes::as_hex"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_bytes::as_hex"))]
     pub kfrag_validity_message_hash: BackendDigestOutput,
     /// The recovery byte corresponding to `kfrag_signature` in [`CapsuleFrag::to_bytes_simple`]
     /// (`true` corresponds to `0x01` and `false` to `0x00`).

--- a/umbral-pre/src/key_frag.rs
+++ b/umbral-pre/src/key_frag.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use alloc::string::String;
 
 use alloc::boxed::Box;
@@ -8,7 +8,7 @@ use core::fmt;
 use generic_array::{typenum::U32, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::curve::{CurvePoint, CurveScalar, NonZeroCurveScalar};
@@ -21,7 +21,7 @@ use crate::traits::fmt_public;
 #[cfg(feature = "default-serialization")]
 use crate::{DefaultDeserialize, DefaultSerialize};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use crate::serde_bytes::{
     deserialize_with_encoding, serialize_with_encoding, Encoding, TryFromBytes,
 };
@@ -47,7 +47,7 @@ impl AsRef<[u8]> for KeyFragID {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl Serialize for KeyFragID {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -57,7 +57,7 @@ impl Serialize for KeyFragID {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for KeyFragID {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for KeyFragID {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for KeyFragID {
     type Error = String;
 
@@ -79,7 +79,7 @@ impl TryFromBytes for KeyFragID {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) struct KeyFragProof {
     pub(crate) commitment: CurvePoint,
     signature_for_proxy: Signature,
@@ -146,7 +146,7 @@ impl KeyFragProof {
 
 /// A fragment of the encrypting party's key used to create a [`CapsuleFrag`](`crate::CapsuleFrag`).
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct KeyFrag {
     params: Parameters,
     pub(crate) id: KeyFragID,
@@ -303,8 +303,8 @@ impl<'de> DefaultDeserialize<'de> for KeyFrag {}
 /// Can be serialized, but cannot be deserialized directly.
 /// It can only be obtained from [`KeyFrag::verify`] or [`KeyFrag::skip_verification`].
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize))]
-#[cfg_attr(feature = "serde-support", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct VerifiedKeyFrag {
     kfrag: KeyFrag,
 }
@@ -420,7 +420,7 @@ mod tests {
 
     use crate::{PublicKey, SecretKey, Signer};
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     use crate::serde_bytes::tests::check_serialization_roundtrip;
 
     fn prepare_kfrags(
@@ -494,7 +494,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serde_serialization() {
         let (_delegating_pk, _receiving_pk, _verifying_pk, verified_kfrags) =

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -22,7 +22,7 @@ use zeroize::ZeroizeOnDrop;
 #[cfg(feature = "default-rng")]
 use rand_core::OsRng;
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::curve::{CompressedPointSize, CurvePoint, CurveType, NonZeroCurveScalar, ScalarSize};
@@ -31,7 +31,7 @@ use crate::hashing::{BackendDigest, Hash, ScalarDigest};
 use crate::secret_box::SecretBox;
 use crate::traits::{fmt_public, fmt_secret, SizeMismatchError};
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use crate::serde_bytes::{
     deserialize_with_encoding, serialize_with_encoding, Encoding, TryFromBytes,
 };
@@ -94,8 +94,8 @@ impl Signature {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -105,8 +105,8 @@ impl Serialize for Signature {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Signature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -116,7 +116,7 @@ impl<'de> Deserialize<'de> for Signature {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for Signature {
     type Error = String;
 
@@ -184,8 +184,8 @@ impl RecoverableSignature {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for RecoverableSignature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -195,8 +195,8 @@ impl Serialize for RecoverableSignature {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for RecoverableSignature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -206,7 +206,7 @@ impl<'de> Deserialize<'de> for RecoverableSignature {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for RecoverableSignature {
     type Error = String;
 
@@ -379,8 +379,8 @@ impl PublicKey {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -390,8 +390,8 @@ impl Serialize for PublicKey {
     }
 }
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -401,7 +401,7 @@ impl<'de> Deserialize<'de> for PublicKey {
     }
 }
 
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 impl TryFromBytes for PublicKey {
     type Error = String;
 
@@ -511,7 +511,7 @@ mod tests {
         digest_for_signing, PublicKey, RecoverableSignature, SecretKey, SecretKeyFactory, Signer,
     };
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     use crate::serde_bytes::tests::check_serialization_roundtrip;
 
     #[test]
@@ -575,7 +575,7 @@ mod tests {
         panic!("Could not find a flag that would recover the original public key");
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_signature() {
         let message = b"asdafdahsfdasdfasd";
@@ -585,7 +585,7 @@ mod tests {
         check_serialization_roundtrip(&signature);
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_recoverable_signature() {
         let message = b"asdafdahsfdasdfasd";
@@ -595,7 +595,7 @@ mod tests {
         check_serialization_roundtrip(&rsig);
     }
 
-    #[cfg(feature = "serde-support")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_public_key() {
         let signer = Signer::new(SecretKey::random());

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -95,7 +95,6 @@ impl Signature {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -106,7 +105,6 @@ impl Serialize for Signature {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Signature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -185,7 +183,6 @@ impl RecoverableSignature {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for RecoverableSignature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -196,7 +193,6 @@ impl Serialize for RecoverableSignature {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for RecoverableSignature {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -237,7 +233,6 @@ impl SecretKey {
 
     /// Creates a secret key using the default RNG.
     #[cfg(feature = "default-rng")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn random() -> Self {
         Self::random_with_rng(&mut OsRng)
     }
@@ -304,7 +299,6 @@ impl Signer {
 
     /// Signs the given message using the default RNG.
     #[cfg(feature = "default-rng")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn sign(&self, message: &[u8]) -> Signature {
         self.sign_with_rng(&mut OsRng, message)
     }
@@ -380,7 +374,6 @@ impl PublicKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -391,7 +384,6 @@ impl Serialize for PublicKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -435,7 +427,6 @@ impl SecretKeyFactory {
 
     /// Creates a secret key factory using the default RNG.
     #[cfg(feature = "default-rng")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
     pub fn random() -> Self {
         Self::random_with_rng(&mut OsRng)
     }

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -119,14 +119,11 @@ extern crate std;
 extern crate alloc;
 
 #[cfg(feature = "bench-internals")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bench-internals")))]
 pub mod bench; // Re-export some internals for benchmarks.
 
 #[cfg(feature = "bindings-python")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bindings-python")))]
 pub mod bindings_python;
 #[cfg(feature = "bindings-wasm")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bindings-wasm")))]
 pub mod bindings_wasm;
 
 mod capsule;
@@ -144,7 +141,6 @@ mod secret_box;
 mod traits;
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_bytes;
 
 pub use capsule::{Capsule, OpenReencryptedError};

--- a/umbral-pre/src/lib.rs
+++ b/umbral-pre/src/lib.rs
@@ -14,7 +14,7 @@
 //! * `default-serialization` - adds methods for default binary serialization
 //!    that matches the serialization in the bindings.
 //!    MessagePack, `serde`-based.
-//! * `serde-support` - implements `serde`-based serialization and deserialization.
+//! * `serde` - implements `serde`-based serialization and deserialization.
 //! * `bindings-python` - adds a `bindings_python` submodule allowing dependent crates
 //!        to use and re-export some of the Python-wrapped Umbral types.
 //! * `bindings-wasm` - adds a `bindings_wasm` submodule allowing dependent crates
@@ -143,8 +143,8 @@ mod pre;
 mod secret_box;
 mod traits;
 
-#[cfg(feature = "serde-support")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde-support")))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_bytes;
 
 pub use capsule::{Capsule, OpenReencryptedError};

--- a/umbral-pre/src/params.rs
+++ b/umbral-pre/src/params.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::curve::CurvePoint;
 
 /// An object containing shared scheme parameters.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Parameters {
     /// The re-encryption parameter `u`.
     pub u: CurvePoint,

--- a/umbral-pre/src/pre.rs
+++ b/umbral-pre/src/pre.rs
@@ -50,7 +50,6 @@ pub fn encrypt_with_rng(
 
 /// A synonym for [`encrypt`] with the default RNG.
 #[cfg(feature = "default-rng")]
-#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 pub fn encrypt(
     delegating_pk: &PublicKey,
     plaintext: &[u8],
@@ -113,7 +112,6 @@ pub fn generate_kfrags_with_rng(
 
 /// A synonym for [`generate_kfrags_with_rng`] with the default RNG.
 #[cfg(feature = "default-rng")]
-#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 #[allow(clippy::too_many_arguments)]
 pub fn generate_kfrags(
     delegating_sk: &SecretKey,
@@ -154,7 +152,6 @@ pub fn reencrypt_with_rng(
 
 /// A synonym for [`reencrypt_with_rng`] with the default RNG.
 #[cfg(feature = "default-rng")]
-#[cfg_attr(docsrs, doc(cfg(feature = "default-rng")))]
 pub fn reencrypt(capsule: &Capsule, verified_kfrag: VerifiedKeyFrag) -> VerifiedCapsuleFrag {
     reencrypt_with_rng(&mut OsRng, capsule, verified_kfrag)
 }


### PR DESCRIPTION
It is conventional in the Rust ecosystem to have features that enable one dependency have the name of that dependency.