### PR TITLE
Use fixed-size serde serialization for signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped MSRV to 1.60. ([#117])
 - Bumped `k256` to 0.12 and PyO3 to `0.18`. ([#117])
 - Renamed `serde-support` feature to `serde` to match the conventional style. ([#118])
+- `serde` implementation for `Signature` now uses fixed-size (r,s) serialization instead of DER. ([#119])
 
 
 ### Added
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#107]: https://github.com/nucypher/rust-umbral/pull/107
 [#117]: https://github.com/nucypher/rust-umbral/pull/117
 [#118]: https://github.com/nucypher/rust-umbral/pull/118
+[#119]: https://github.com/nucypher/rust-umbral/pull/119
 
 
 ## [0.8.1] - 2023-01-17

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -100,7 +100,7 @@ impl Serialize for Signature {
     where
         S: Serializer,
     {
-        serialize_with_encoding(&self.to_der_bytes(), serializer, Encoding::Hex)
+        serialize_with_encoding(&self.to_be_bytes(), serializer, Encoding::Hex)
     }
 }
 
@@ -119,13 +119,13 @@ impl TryFromBytes for Signature {
     type Error = String;
 
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::try_from_der_bytes(bytes)
+        Self::try_from_be_bytes(bytes)
     }
 }
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_public("Signature", &self.to_der_bytes(), f)
+        fmt_public("Signature", &self.to_be_bytes(), f)
     }
 }
 


### PR DESCRIPTION
This matches the default serialization for `RecoverableSignature` (and for that one it is non-trivial to implement DER serialization, since we have to do it manually). So let's just use the fixed-size representation everywhere.