### PR TITLE
Bump `wasm-bindgen` and `wasm-bindgen-derive` versions

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.60.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 

--- a/umbral-pre-wasm/Cargo.toml
+++ b/umbral-pre-wasm/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 umbral-pre = { path = "../umbral-pre", features = ["bindings-wasm"] }
-wasm-bindgen = "0.2.74"
-js-sys = "0.3.51"
+wasm-bindgen = "0.2.86"
+js-sys = "0.3.63"

--- a/umbral-pre/Cargo.toml
+++ b/umbral-pre/Cargo.toml
@@ -19,10 +19,10 @@ serde = { version = "1", default-features = false, features = ["derive"], option
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 rmp-serde = { version = "1", optional = true }
 pyo3 = { version = "0.18", optional = true }
-js-sys = { version = "0.3", optional = true }
-wasm-bindgen = { version = "0.2.74", optional = true }
+js-sys = { version = "0.3.63", optional = true }
+wasm-bindgen = { version = "0.2.86", optional = true }
 derive_more = { version = "0.99", optional = true, default_features = false, features = ["as_ref", "from", "into"] }
-wasm-bindgen-derive = { version = "0.1", optional = true }
+wasm-bindgen-derive = { version = "0.2.0", optional = true }
 
 # These packages are among the dependencies of the packages above.
 # Their versions should be updated when the main packages above are updated.


### PR DESCRIPTION
- Fixes issue with `wasm-bindgen-derive` in `nucypher-core` and `ferveo` integration: https://github.com/nucypher/nucypher-core/pull/53#issuecomment-1561189441
- Tested locally