### PR TITLE
Allow external access to the SecretBox::new method

### DIFF
--- a/umbral-pre/src/secret_box.rs
+++ b/umbral-pre/src/secret_box.rs
@@ -45,7 +45,8 @@ impl<T> SecretBox<T>
 where
     T: Zeroize + Clone,
 {
-    pub(crate) fn new(val: T) -> Self {
+    /// Creates an new instance of an immutable reference to the secret data.
+    pub fn new(val: T) -> Self {
         Self(Box::new(val))
     }
 


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- TBD

**What this does:**
- Changes the visibility of the `SecretBox::new` method from `pub(crate)` to `pub`.

**Why it's needed:**
- Currently, there is no way to instantiate a `SecretBox` from outside the library.
- The absence of an alternative method makes it impossible to instantiate a `SecretKey`.
- Instantiating a `SecretKey` outside the library is necessary, for example, when an application stores the secret key in a file and needs to retrieve it.

**Notes for reviewers:**
- This issue is not present on the WASM and Python APIs because the facades providing those interfaces use the `SecretBox::new` method internally.
- This is a minor change; however, I am unaware of the original reasoning for making this method only visible within the crate. 
- This is my first pull request, so any suggestions for future PRs are always welcome.