### PR TITLE
Make `SecretKey::try_from_be_bytes()` take just a slice reference

### DIFF
--- a/.github/workflows/umbral-pre.yml
+++ b/.github/workflows/umbral-pre.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.70.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.70.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.70.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.65.0 # MSRV
+            rust: 1.70.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.12.0] - In development
+
+### Changed
+
+- `SecretKey::try_from_be_bytes()` takes just a slice reference instead of a `SecretBox`. ([#134])
+
+
+[#134]: https://github.com/nucypher/rust-umbral/pull/134
+
+
 ## [0.11.0] - 2023-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `SecretKey::try_from_be_bytes()` takes just a slice reference instead of a `SecretBox`. ([#134])
+- Bumped MSRV to 1.70. ([#134])
 
 
 [#134]: https://github.com/nucypher/rust-umbral/pull/134

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -24,7 +24,7 @@ use pyo3::wrap_pyfunction;
 use sha2::{digest::Update, Digest, Sha256};
 
 use crate as umbral_pre;
-use crate::{curve::ScalarSize, DefaultDeserialize, DefaultSerialize, SecretBox};
+use crate::{DefaultDeserialize, DefaultSerialize};
 
 fn map_py_value_err<T: fmt::Display>(err: T) -> PyErr {
     PyValueError::new_err(format!("{err}"))
@@ -101,11 +101,7 @@ impl SecretKey {
 
     #[staticmethod]
     pub fn from_be_bytes(data: &[u8]) -> PyResult<Self> {
-        let arr = SecretBox::new(
-            GenericArray::<u8, ScalarSize>::from_exact_iter(data.iter().cloned())
-                .ok_or_else(|| map_py_value_err("Invalid length of a curve scalar"))?,
-        );
-        umbral_pre::SecretKey::try_from_be_bytes(&arr)
+        umbral_pre::SecretKey::try_from_be_bytes(data)
             .map_err(map_py_value_err)
             .map(Self::from)
     }

--- a/umbral-pre/src/bindings_python.rs
+++ b/umbral-pre/src/bindings_python.rs
@@ -3,10 +3,6 @@
 // TODO (#30): ideally, we would write documentation for the bindings as docstrings here,
 // and let Sphinx pick it up... but it's not great at doing so.
 #![allow(missing_docs)]
-// Clippy shows false positives in PyO3 methods.
-// See https://github.com/rust-lang/rust-clippy/issues/8971
-// Will probably be fixed by Rust 1.65
-#![allow(clippy::borrow_deref_ref)]
 
 use alloc::format;
 use alloc::string::String;

--- a/umbral-pre/src/bindings_wasm.rs
+++ b/umbral-pre/src/bindings_wasm.rs
@@ -14,14 +14,13 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
 
-use generic_array::GenericArray;
 use js_sys::{Error, Uint8Array};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_derive::TryFromJsValue;
 
 use crate as umbral_pre;
-use crate::{curve::ScalarSize, DefaultDeserialize, DefaultSerialize, SecretBox};
+use crate::{DefaultDeserialize, DefaultSerialize};
 
 #[wasm_bindgen]
 extern "C" {
@@ -104,11 +103,7 @@ impl SecretKey {
 
     #[wasm_bindgen(js_name = fromBEBytes)]
     pub fn from_be_bytes(data: &[u8]) -> Result<SecretKey, Error> {
-        let arr = SecretBox::new(
-            GenericArray::<u8, ScalarSize>::from_exact_iter(data.iter().cloned())
-                .ok_or_else(|| map_js_err("Invalid length of a curve scalar"))?,
-        );
-        umbral_pre::SecretKey::try_from_be_bytes(&arr)
+        umbral_pre::SecretKey::try_from_be_bytes(data)
             .map(Self)
             .map_err(map_js_err)
     }

--- a/umbral-pre/src/keys.rs
+++ b/umbral-pre/src/keys.rs
@@ -261,10 +261,12 @@ impl SecretKey {
     }
 
     /// Deserializes the secret key from a scalar in the big-endian representation.
-    pub fn try_from_be_bytes(
-        bytes: &SecretBox<GenericArray<u8, ScalarSize>>,
-    ) -> Result<Self, String> {
-        BackendSecretKey::<CurveType>::from_bytes(bytes.as_secret())
+    pub fn try_from_be_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let arr = SecretBox::new(
+            GenericArray::<u8, ScalarSize>::from_exact_iter(bytes.iter().cloned())
+                .ok_or("Invalid length of a curve scalar")?,
+        );
+        BackendSecretKey::<CurveType>::from_bytes(arr.as_secret())
             .map(Self::new)
             .map_err(|err| format!("{err}"))
     }


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**What this does:**
- Make `SecretKey::try_from_be_bytes()` take just a slice reference; it's the caller's responsibility to ensure that the storage is zeroized. 
- Bump MSRV to 1.70

This overrides #132. 